### PR TITLE
remove `utils.string_types`

### DIFF
--- a/mkdocs_bibtex/plugin.py
+++ b/mkdocs_bibtex/plugin.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 
 from mkdocs.config import config_options
 from mkdocs.plugins import BasePlugin
-from mkdocs import utils
 
 from pybtex.style.formatting.plain import Style as PlainStyle
 from pybtex.backends.markdown import Backend as MarkdownBackend
@@ -29,16 +28,16 @@ class BibTexPlugin(BasePlugin):
     """
 
     config_scheme = [
-        ("bib_file", config_options.Type(utils.string_types, required=False)),
-        ("bib_dir", config_options.Type(utils.string_types, required=False)),
-        ("cite_style", config_options.Type(utils.string_types, default="pandoc")),
+        ("bib_file", config_options.Type(str, required=False)),
+        ("bib_dir", config_options.Type(str, required=False)),
+        ("cite_style", config_options.Type(str, default="pandoc")),
         (
             "bib_command",
-            config_options.Type(utils.string_types, default="\\bibliography"),
+            config_options.Type(str, default="\\bibliography"),
         ),
         (
             "full_bib_command",
-            config_options.Type(utils.string_types, default="\\full_bibliography"),
+            config_options.Type(str, default="\\full_bibliography"),
         ),
     ]
 


### PR DESCRIPTION
Not needed anymore, see https://github.com/mkdocs/mkdocs/blob/1.0.4/mkdocs/utils/__init__.py#L35