### PR TITLE
Change from pybtex to pypandoc, resolves #4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# PyCharm
+.idea

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Install the plugin using pip:
 pip install mkdocs-bibtex
 ```
 
+This version relies on Pandoc through [pypandoc](https://pypi.org/project/pypandoc/). 
+Pypandoc provides Pandoc on many systems, otherwise, you have to install Pandoc manually, 
+see pypandoc documentation for more details. 
+
 Next, add the following lines to your `mkdocs.yml`:
 
 ```yml
@@ -21,23 +25,24 @@ plugins:
   - search
   - bibtex:
       bib_file: "refs.bib"
-      cite_style: "pandoc"
 ```
 
 > If you have no `plugins` entry in your config file yet, you'll likely also want to add the `search` plugin. MkDocs enables it by default if there is no `plugins` entry set.
 
 ## Options
 
-- `bib_file` - Name of your bibtex file. Either the absolute path or the path relative to `mkdocs.yml`
-- `bib_dir` - Directory for bibtex files to load, same as above for path resolution
-- `cite_style` - The way you place citations into text: "pandoc" for `[@myRef]` and "plain" for `@myRef`
-- `bib_command` - The command for your bibliography, defaults to `\bibliography`
-- `full_bib_command` - The command for your bibliography, defaults to `\full_bibliography`
+- `bib_file` - Name of your bibtex file. Either the absolute path or the path relative to `mkdocs.yml`.
+- `csl_file` - Name of your [CSL](https://citationstyles.org/) file. Either the absolute path or the path relative to `mkdocs.yml`
 
 ## Usage
 
-In your markdown files:
+In your markdown files, add your citations as you would normally using ["pandoc"](https://pandoc.org/MANUAL.html#citations) style. 
+Citations go inside square brackets and are separated by semicolons. 
+Each citation must have a key, composed of ‘@’ + the citation identifier from the database.
 
-1. Add your citations as you would normally using either "plain" or "pandoc" style
-2. Add in `\bibliography` or whatever you set your `bib_command` to where you want your references.
-3. Add in `\full_bibliography` or whatever you set your `full_bib_command` to where you want the full set of references. *Note*: This is not guaranteed to work yet since one issue is the order in which markdown files are processed. Might need to do something using the `on_files()` event first.
+If the style calls for a list of works cited, it will be placed in a div with id `refs`, if one exists:
+```markdown
+::: {#refs}
+:::
+```
+Otherwise, it will be placed at the end of the document.

--- a/mkdocs_bibtex/plugin.py
+++ b/mkdocs_bibtex/plugin.py
@@ -1,172 +1,58 @@
-import re
-import glob
 import os.path
-from collections import OrderedDict
 
+import pypandoc
 from mkdocs.config import config_options
 from mkdocs.plugins import BasePlugin
-
-from pybtex.style.formatting.plain import Style as PlainStyle
-from pybtex.backends.markdown import Backend as MarkdownBackend
-from pybtex.database import parse_file, BibliographyData
 
 
 class BibTexPlugin(BasePlugin):
     """
-    Allows the use of bibtex in markdown content for MKDocs
+    Allows the use of bibtex in markdown content for MKDocs.
 
     Options:
-        bib_file (string): path to a single bibtex file for entries
-        bib_dir (string): path to a directory of bibtex files for entries
-        cite_style (string): either "plain" or "pandoc" to define the cite key style
-                             defaults to "pandoc"
-            plain - @cite_key
-            pandoc - [@cite_key]
-        bib_command (string): command to place a bibliography relevant to just that file
-                              defaults to \bibliography
-        full_bib_command (string): command to place a full bibliography of all references
+        bib_file (string): path to a single bibtex file for entries, relative to mkdocs.yml.
+        csl_file (string, optional): path to a CLS file, relative to mkdocs.yml.
     """
 
     config_scheme = [
-        ("bib_file", config_options.Type(str, required=False)),
-        ("bib_dir", config_options.Type(str, required=False)),
-        ("cite_style", config_options.Type(str, default="pandoc")),
-        ("bib_command", config_options.Type(str, default="\\bibliography")),
-        ("full_bib_command", config_options.Type(str, default="\\full_bibliography")),
+        ("bib_file", config_options.Type(str, required=True)),  # TODO: multiple files.
+        ("csl_file", config_options.Type(str, required=False)),
     ]
 
-    def __init__(self):
-        self.bib_data = None
-        self.all_references = OrderedDict()
-
     def on_config(self, config):
-        """
-        Loads bibliography on load of config
-        """
+        """Get path on load of config."""
         config_path = os.path.dirname(config.config_file_path)
 
-        bibfiles = []
-
-        if self.config.get("bib_file", None) is not None:
-            bibfiles.append(get_path(self.config["bib_file"], config_path))
-        elif self.config.get("bib_dir", None) is not None:
-            bibfiles.extend(
-                glob.glob(
-                    get_path(os.path.join(self.config["bib_dir"], "*.bib"), config_path)
-                )
-            )
-        else:
-            raise Exception("Must supply a bibtex file or directory for bibtex files")
-
-        # load bibliography data
-        refs = {}
-        for bibfile in bibfiles:
-            bibfile = get_path(bibfile, config_path)
-            bibdata = parse_file(bibfile)
-            refs.update(bibdata.entries)
-
-        self.bib_data = BibliographyData(entries=refs)
-
-        cite_style = config.get("cite_style", "pandoc")
-        # Decide on how citations are entered into the markdown text
-        if cite_style == "plain":
-            self.cite_regex = re.compile(r"\@(\w+)")
-            self.insert_regex = r"\@{}"
-        elif cite_style == "pandoc":
-            self.cite_regex = re.compile(r"\[\@(\w+)\]")
-            self.insert_regex = r"\[@{}\]"
-        else:
-            raise Exception("Invalid citation style: {}".format(cite_style))
+        self.csl_path = get_path(self.config.get("csl_file", None), config_path)
+        self.bib_path = get_path(self.config["bib_file"], config_path)
 
         return config
 
     def on_page_markdown(self, markdown, page, config, files):
-        """
-        Parses the markdown for each page, extracting the bibtex references
-        If a local reference list is requested, this will render that list where requested
 
-        1. Finds all cite keys
-        2. Convert all the corresponding bib entries into citations
-        3. Insert the ordered citation numbers into the markdown text
-        4. Insert the bibliography into the markdown
-        5. Insert teh full bibliograph into the markdown
-        """
+        to = "markdown_strict"
+        input_format = "md"
+        extra_args = []
 
-        # 1. Grab all the cited keys in the markdown
-        cite_keys = self.cite_regex.findall(markdown)
-        citations = [
-            (cite_key, self.bib_data.entries[cite_key])
-            for cite_key in cite_keys
-            if cite_key in self.bib_data.entries
-        ]
+        # Add bibtex files.
+        # TODO: multiple bib files. Pandoc supports multiple "--bibliography" args,
+        #  but I don't know yet how to get a list from the config.
+        extra_args.extend(["--bibliography", self.bib_path])
 
-        # 2. Convert all the citations to text references
-        references = self.format_citations(citations)
+        # Add CSL files.
+        if self.csl_path is not None:
+            extra_args.extend(["--csl", self.csl_path])
 
-        # 3. Insert in numbers into the main markdown and build bibliography
-        bibliography = []
-        for number, key in enumerate(references.keys()):
-            markdown = re.sub(
-                self.insert_regex.format(key), "[^{}]".format(number + 1), markdown
-            )
-            bibliography_text = "[^{}]: {}".format(number + 1, references[key])
-            bibliography.append(bibliography_text)
+        # Call Pandoc.
+        markdown = pypandoc.convert_text(markdown, to, input_format, extra_args)
 
-        # 4. Insert in the bibliopgrahy text into the markdown
-        bibliography = "\n\n".join(bibliography)
-        markdown = re.sub(
-            re.escape(self.config.get("bib_command", "\\bibliography")),
-            bibliography,
-            markdown,
-        )
-
-        # 5. Build the full Bibliography and insert into the text
-        markdown = re.sub(
-            re.escape(self.config.get("full_bib_command", "\\full_bibliography")),
-            self.full_bibliography,
-            markdown,
-        )
-
-        return markdown
-
-    def format_citations(self, citations):
-        """
-        Formats references and adds them to the global registry
-
-        Args:
-            citations (dict): mapping of cite_key to entry
-
-        Returns OrderedDict of references
-        """
-        style = PlainStyle()
-        backend = MarkdownBackend()
-        references = OrderedDict()
-        for key, entry in citations:
-            formatted_entry = style.format_entry("", entry)
-            entry_text = formatted_entry.text.render(backend)
-            entry_text = entry_text.replace("\n", " ")
-            # Local reference list for this file
-            references[key] = entry_text
-            # Global reference list for all files
-            self.all_references[key] = entry_text
-        return references
-
-    @property
-    def full_bibliography(self):
-        """
-        Returns the full bibliography text
-        """
-        full_bibliography = []
-
-        for number, key in enumerate(self.all_references.keys()):
-            bibliography_text = "{}: {}".format(number + 1, self.all_references[key])
-            full_bibliography.append(bibliography_text)
-
-        return "\n".join(full_bibliography)
+        return str(markdown)
 
 
 def get_path(path, base_path):
-    if os.path.isabs(path):
+    if path is None:
+        return None
+    elif os.path.isabs(path):
         return path
     else:
         return os.path.abspath(os.path.join(base_path, path))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-mkdocs==1.1
-markdown==3.2.1
-pybtex==0.22.2
+mkdocs==1.1.2
+markdown==3.2.2
+pypandoc==1.5

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author_email="shyamd@lbl.gov",
     license="BSD-3-Clause-LBNL",
     python_requires=">=3.5",
-    install_requires=["mkdocs>=1", "markdown>=3.1.1", "pybtex>=0.22"],
+    install_requires=["mkdocs>=1", "markdown>=3.1.1", "pypandoc>=1.5"],
     tests_require=["pytest"],
     packages=find_packages(),
     entry_points={"mkdocs.plugins": ["bibtex = mkdocs_bibtex.plugin:BibTexPlugin"]},


### PR DESCRIPTION
This pull request changes backend from pybtex to pypandoc, resolving #4.

This has two caveats:

1. I have not implemented multiple bib files.

2. This is a big one: it uses Pandoc, and modifies not only the bibliography, but everything else that Pandoc can handle. It outputs strict markdown, converting any fancy tags/extensions that Pandoc can recognize into plain markdown.

Depending on the goals of the plugin, this change might be too drastic. Perhaps it might be more suitable for a separate plugin. In that case, feel free to reject this PR.