### PR TITLE
Add links from citations to full bibliography item

### DIFF
--- a/mkdocs_bibtex/plugin.py
+++ b/mkdocs_bibtex/plugin.py
@@ -112,9 +112,9 @@ class BibTexPlugin(BasePlugin):
         bibliography = []
         for number, key in enumerate(references.keys()):
             markdown = re.sub(
-                self.insert_regex.format(key), "[^{}]".format(number + 1), markdown
+                self.insert_regex.format(key), "[{}]".format(number + 1), markdown
             )
-            bibliography_text = "[^{}]: {}".format(number + 1, references[key])
+            bibliography_text = "[{}]: {}".format(number + 1, references[key])
             bibliography.append(bibliography_text)
 
         # 4. Insert in the bibliopgrahy text into the markdown

--- a/mkdocs_bibtex/plugin.py
+++ b/mkdocs_bibtex/plugin.py
@@ -36,6 +36,7 @@ class BibTexPlugin(BasePlugin):
         ("bib_command", config_options.Type(str, default="\\bibliography")),
         ("full_bib_command", config_options.Type(str, default="\\full_bibliography")),
         ("csl_file", config_options.Type(str, required=False)),
+        ("full_bib_page", config_options.Type(str, required=False, default="references")),
     ]
 
     def __init__(self):
@@ -109,10 +110,13 @@ class BibTexPlugin(BasePlugin):
         references = self.format_citations(citations)
 
         # 3. Insert in numbers into the main markdown and build bibliography
+        full_bibliography_page = self.config.get("full_bib_page")
+        anchor = "<a href='" + full_bibliography_page + "#{}'>[{}]</a>"
         bibliography = []
         for number, key in enumerate(references.keys()):
+            formatted_anchor = anchor.format(key, number + 1)
             markdown = re.sub(
-                self.insert_regex.format(key), "[{}]".format(number + 1), markdown
+                self.insert_regex.format(key), formatted_anchor, markdown
             )
             bibliography_text = "[{}]: {}".format(number + 1, references[key])
             bibliography.append(bibliography_text)
@@ -166,8 +170,10 @@ class BibTexPlugin(BasePlugin):
         """
         full_bibliography = []
 
+        anchor = "<a id='{}'>{}</a>"
         for number, key in enumerate(self.all_references.keys()):
-            bibliography_text = "{}: {}".format(number + 1, self.all_references[key])
+            formatted_anchor = anchor.format('#' + key, number + 1)
+            bibliography_text = "{}: {}".format(formatted_anchor, self.all_references[key])
             full_bibliography.append(bibliography_text)
 
         return "\n".join(full_bibliography)

--- a/mkdocs_bibtex/test_plugin.py
+++ b/mkdocs_bibtex/test_plugin.py
@@ -62,6 +62,6 @@ class TestPlugin(unittest.TestCase):
         test_markdown = "This is a citation. [@test]\n\n \\bibliography"
 
         self.assertIn(
-            "[^1]: First Author and Second Author\. Test title\. *Testing Journal*, 2019\.",
+            "First Author and Second Author\. Test title\. *Testing Journal*, 2019\.",
             self.plugin.on_page_markdown(test_markdown, None, None, None),
         )


### PR DESCRIPTION
This PR adds:
- anchors with `id=${key}` to the identifier of each bibliography item in the full bibliography only, and
- anchors with `href` that makes each citation occurrence to point to the associated anchor at the previous point
- a new configuration field `full_bib_page` that points to the webpage with the full bibliography.

The benefit for the user is that in order to discover the citation, he just needs to click to the occurrence of the citation number (i.e. `[1]`), which is now a link that brings to the references page.

The feature is not perfectly implemented. It works best when the documentation has only one webpage containing the `\fullbibliography`. If there are more, the anchors into one of the two are mostly useless; maybe it's worth having control over that at the plugin level. Another point is whether also `\bibliography` should have anchors, and how. Also, we should take into account other corner cases and if the new feature integrates well with all the others, and if not provide more documentation. 

I'm here to ask your feedback on this feature. If you like it, I can provide more tests and give my help in making it better :-) 

You can see a live example [here](https://marcofavorito.github.io/yarllib/quickstart/) (look at the `[1]` at the end of the first sentence).