### PR TITLE
updated "pandoc" style regex to accept some punctuation

### DIFF
--- a/mkdocs_bibtex/plugin.py
+++ b/mkdocs_bibtex/plugin.py
@@ -76,7 +76,7 @@ class BibTexPlugin(BasePlugin):
             self.cite_regex = re.compile(r"\@(\w+)")
             self.insert_regex = r"\@{}"
         elif cite_style == "pandoc":
-            self.cite_regex = re.compile(r"\[\@(\w+)\]")
+            self.cite_regex = re.compile(r"\[\@((?:(?:\w+)[\-:]?)+)\]")
             self.insert_regex = r"\[@{}\]"
         else:
             raise Exception("Invalid citation style: {}".format(cite_style))


### PR DESCRIPTION
in order to accept bibs that have hyphens and colons, for example:

@inproceedings{Al-Twairesh:2018:suar,
