### PR TITLE
Fix Pandoc Parsing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,4 +10,3 @@ repos:
       rev: stable
       hooks:
       - id: black
-        language_version: python3.7

--- a/mkdocs_bibtex/plugin.py
+++ b/mkdocs_bibtex/plugin.py
@@ -195,10 +195,17 @@ def to_markdown_pandoc(entry, csl_path):
             ],
         )
 
+        # This should cut off the pandoc preamble and ending triple colons
+        markdown = "\n".join(markdown.split("\n")[2:-2])
+
         citation_regex = re.compile(
             r"\{\.csl-left-margin\}\[(.*)\]\{\.csl-right-inline\}"
         )
-        citation = citation_regex.findall(" ".join(markdown.split("\n")))[0]
+        try:
+
+            citation = citation_regex.findall(" ".join(markdown.split("\n")))[0]
+        except IndexError:
+            citation = " ".join(markdown.split("\n"))
     else:
         # Older citeproc-filter version of pandoc
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/mkdocs_bibtex/plugin.py
+++ b/mkdocs_bibtex/plugin.py
@@ -226,5 +226,6 @@ nocite: '@*'
                 filters=["pandoc-citeproc"],
             )
 
-        citation = markdown.replace("\n", " ")[4:]
+        citation_regex = re.compile(r"(?:1\.)?(.*)")
+        citation = citation_regex.findall(markdown.replace("\n", " "))[0]
     return citation

--- a/mkdocs_bibtex/plugin.py
+++ b/mkdocs_bibtex/plugin.py
@@ -196,16 +196,16 @@ def to_markdown_pandoc(entry, csl_path):
         )
 
         # This should cut off the pandoc preamble and ending triple colons
-        markdown = "\n".join(markdown.split("\n")[2:-2])
+        markdown = " ".join(markdown.split("\n")[2:-2])
 
         citation_regex = re.compile(
             r"\{\.csl-left-margin\}\[(.*)\]\{\.csl-right-inline\}"
         )
         try:
 
-            citation = citation_regex.findall(" ".join(markdown.split("\n")))[0]
+            citation = citation_regex.findall(markdown)[0]
         except IndexError:
-            citation = " ".join(markdown.split("\n"))
+            citation = markdown
     else:
         # Older citeproc-filter version of pandoc
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/mkdocs_bibtex/test_plugin.py
+++ b/mkdocs_bibtex/test_plugin.py
@@ -87,6 +87,12 @@ class TestPlugin(unittest.TestCase):
         self.plugin.format_citations(test_data.entries.items())
         self.assertIn("Author, F. & Author, S", self.plugin.full_bibliography)
 
+        self.plugin.csl_file = os.path.join(
+            test_files_dir, "springer-basic-author-date.csl"
+        )
+        self.plugin.format_citations(test_data.entries.items())
+        self.assertIn("Author F, Author S", self.plugin.full_bibliography)
+
     def test_on_page_markdown(self):
         self.plugin.on_config(self.plugin.config)
         test_markdown = "This is a citation. [@test]\n\n \\bibliography"

--- a/mkdocs_bibtex/test_plugin.py
+++ b/mkdocs_bibtex/test_plugin.py
@@ -23,13 +23,13 @@ class TestPlugin(unittest.TestCase):
 
         self.plugin.unescape_for_arithmatex = True
         self.assertIn(
-            "First Author and Second Author\. Test Title (TT)\. *Testing Journal (TJ)*, 2019",
+            "First Author and Second Author\\. Test Title (TT)\\. *Testing Journal (TJ)*, 2019",
             self.plugin.format_citations(test_data.entries.items())["test"],
         )
 
         self.plugin.unescape_for_arithmatex = False
         self.assertIn(
-            "First Author and Second Author\. Test Title \(TT\)\. *Testing Journal \(TJ\)*, 2019",
+            "First Author and Second Author\\. Test Title \\(TT\\)\\. *Testing Journal \\(TJ\\)*, 2019",
             self.plugin.format_citations(test_data.entries.items())["test"],
         )
 
@@ -98,6 +98,6 @@ class TestPlugin(unittest.TestCase):
         test_markdown = "This is a citation. [@test]\n\n \\bibliography"
 
         self.assertIn(
-            "[^1]: First Author and Second Author\. Test title\. *Testing Journal*, 2019\.",
+            "[^1]: First Author and Second Author\\. Test title\\. *Testing Journal*, 2019\\.",
             self.plugin.on_page_markdown(test_markdown, None, None, None),
         )

--- a/test_files/springer-basic-author-date.csl
+++ b/test_files/springer-basic-author-date.csl
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" default-locale="en-US" version="1.0" demote-non-dropping-particle="never">
+  <info>
+    <title>Springer - Basic (author-date)</title>
+    <id>http://www.zotero.org/styles/springer-basic-author-date</id>
+    <link href="http://www.zotero.org/styles/springer-basic-author-date" rel="self"/>
+    <link href="http://www.springer.com/cda/content/document/cda_downloaddocument/instruct-authors-e.pdf" rel="documentation"/>
+    <link href="http://www.springer.com/cda/content/document/cda_downloaddocument/manuscript-guidelines-1.0.pdf" rel="documentation"/>
+    <!-- This style corresponds to 'Springer Basic' in the pdf document 'Key Style Points' at this url -->
+    <link href="http://www.springer.com/cda/content/document/cda_downloaddocument/Key_Style_Points_1.0.pdf" rel="documentation"/>
+    <author>
+      <name>Jens Allmer</name>
+      <email>jens@allmer.de</email>
+      <uri>http://jens.allmer.de</uri>
+    </author>
+    <contributor>
+      <name>Sebastian Karcher</name>
+    </contributor>
+    <category citation-format="author-date"/>
+    <category field="generic-base"/>
+    <summary>Springer Author Date Style for the disciplines Medicine, Biomedicine, Life Sciences, Chemistry, Geosciences, Computer Science, Engineering, Economics. This style is based on Harvard style and recommendations of the Council of Biology Editors.</summary>
+    <updated>2019-09-25T12:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale>
+    <terms>
+      <term name="and others">et al</term>
+      <term name="et-al">et al.</term>
+      <term name="edition" form="short">edn.</term>
+    </terms>
+  </locale>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text"/>
+      <et-al/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+      <label form="short" strip-periods="true" prefix=" (" suffix=")"/>
+      <et-al term="and others"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="year">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="book">
+        <group delimiter=". ">
+          <group delimiter=", ">
+            <text variable="title"/>
+            <text macro="edition"/>
+          </group>
+          <choose>
+            <!-- Replace with type="software" as that becomes available -->
+            <if type="book" match="any" variable="version">
+              <text variable="version" prefix="Version "/>
+            </if>
+          </choose>
+        </group>
+      </if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="year-parenth">
+    <date prefix="(" suffix=")" variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year-suffix" cite-group-delimiter=", ">
+    <sort>
+      <key variable="issued"/>
+      <key macro="author"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <group delimiter=" ">
+          <text macro="author-short"/>
+          <text macro="year"/>
+        </group>
+        <group delimiter=" ">
+          <label variable="locator" form="short"/>
+          <text variable="locator"/>
+        </group>
+      </group>
+    </layout>
+  </citation>
+  <bibliography et-al-min="5" et-al-use-first="3" hanging-indent="true">
+    <sort>
+      <key macro="author"/>
+      <key variable="author" sort="ascending"/>
+    </sort>
+    <layout>
+      <group delimiter=" ">
+        <text macro="author"/>
+        <text macro="year-parenth"/>
+        <text macro="title"/>
+      </group>
+      <choose>
+        <!--    Book chapter
+             Brown B, Aaron M (2001) The politics of nature.
+             In: Smith J (ed) The rise of modern genomics, 3rd edn.
+             Wiley, New York, pp 230-257 -->
+        <if type="chapter paper-conference" match="any">
+          <group delimiter=" " prefix=". ">
+            <text term="in" text-case="capitalize-first" suffix=":"/>
+            <names variable="editor">
+              <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+              <label form="short" strip-periods="true" prefix=" (" suffix=")"/>
+            </names>
+            <group delimiter=", ">
+              <text variable="container-title"/>
+              <text macro="edition"/>
+            </group>
+          </group>
+          <group prefix=". " delimiter=", ">
+            <text variable="publisher"/>
+            <text variable="publisher-place"/>
+            <group delimiter=" ">
+              <label variable="page" form="short" strip-periods="true"/>
+              <text variable="page"/>
+            </group>
+          </group>
+        </if>
+        <else-if type="article-journal">
+          <choose>
+            <if variable="page volume" match="any">
+              <!--    Journal article
+                   Gamelin FX, Baquet G, Berthoin S, Thevenet D, Nourry C, Nottin S, Bosquet L (2009)
+                   Effect of high intensity intermittent training on heart rate variability in prepubescent children.
+                   Eur J Appl Physiol 105:731-738. doi: 10.1007/s00421-008-0955-8
+                   Ideally, the names of all authors should be provided, but the usage of "et al"
+                   in long author lists will also be accepted:
+                   Smith J, Jones M Jr, Houghton L et al (1999)
+                   Future of health insurance. N Engl J Med 965:325-329   -->
+              <group prefix=". " delimiter=". ">
+                <group delimiter=" ">
+                  <text variable="container-title" form="short" strip-periods="true"/>
+                  <group delimiter=":">
+                    <text variable="volume" suffix=":"/>
+                    <text variable="page"/>
+                  </group>
+                </group>
+                <text prefix="https://doi.org/" variable="DOI"/>
+              </group>
+            </if>
+            <else>
+              <!--    Article by DOI
+       Slifka MK, Whitton JL (2000) Clinical implications of dysregulated cytokine production.
+       J Mol Med. doi:10.1007/s001090000086     -->
+              <group prefix=". " delimiter=". ">
+                <text variable="container-title" form="short" strip-periods="true"/>
+                <text prefix="https://doi.org/" variable="DOI"/>
+              </group>
+            </else>
+          </choose>
+        </else-if>
+        <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+          <!--    Book
+               South J, Blass B (2001) The future of modern genomics. Blackwell, London    -->
+          <group delimiter=". ">
+            <group prefix=". " delimiter=", ">
+              <text variable="publisher"/>
+              <text variable="publisher-place"/>
+            </group>
+            <group>
+              <choose>
+                <if match="any" variable="version">
+                  <text variable="URL" prefix="URL "/>
+                </if>
+              </choose>
+            </group>
+          </group>
+        </else-if>
+        <else-if type="webpage post-weblog post" match="any">
+          <!--    Online document
+               Doe J (1999) Title of subordinate document. In: The dictionary of substances and their effects.
+               Royal Society of Chemistry. Available via DIALOG.
+               http://www.rsc.org/dose/title of subordinate document. Accessed 15 Jan 1999
+               Unfortunately, "Royal Society of Chemistry. Available via DIALOG." cannot seem to be mapped here -->
+          <group prefix=". " delimiter=". ">
+            <text prefix="In: " variable="container-title" form="short"/>
+            <text variable="URL"/>
+            <date variable="accessed">
+              <date-part prefix="Accessed " name="day" suffix=" "/>
+              <date-part name="month" form="short" suffix=" " strip-periods="true"/>
+              <date-part name="year"/>
+            </date>
+          </group>
+        </else-if>
+        <else-if type="thesis">
+          <!--    Dissertation
+               Trent JW (1975) Experimental acute renal failure. Dissertation, University of California       -->
+          <group prefix=". " delimiter=", ">
+            <text variable="genre" text-case="capitalize-first"/>
+            <text variable="publisher"/>
+          </group>
+        </else-if>
+        <else>
+          <!--    None of the provided formats need to add manually (some data provided) -->
+          <group prefix=". " delimiter=" ">
+            <text variable="container-title" form="short"/>
+            <group delimiter=":">
+              <text variable="volume"/>
+              <text variable="page"/>
+            </group>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
This should fix pandoc parsing for styles that don't output the csl left and right tags. There may be more broken styles out there for now, but I'll fix them as they show up, unless someone who knows CSL style specifications wants to fix pandoc parsing in one go.