### PR TITLE
Fix inline citation numbering

### DIFF
--- a/src/mkdocs_bibtex/plugin.py
+++ b/src/mkdocs_bibtex/plugin.py
@@ -138,10 +138,10 @@ class BibTexPlugin(BasePlugin):
 
         # 3. Construct quads
         quads = []
-        for key_set in cite_keys:
+        for n, key_set in enumerate(cite_keys):
             for key in key_set.strip().strip("]").strip("[").split(";"):
                 key = key.strip().strip("@")
-                quads.append((key_set, key, "1", self.all_references[key]))
+                quads.append((key_set, key, str(n + 1), self.all_references[key]))
 
         return quads
 

--- a/src/mkdocs_bibtex/plugin.py
+++ b/src/mkdocs_bibtex/plugin.py
@@ -123,7 +123,7 @@ class BibTexPlugin(BasePlugin):
         # Deal with arithmatex fix at some point
 
         # 1. First collect any unformated references
-        entries = {}
+        entries = OrderedDict()
         for key_set in cite_keys:
             for key in key_set.strip().strip("]").strip("[").split(";"):
                 key = key.strip().strip("@")

--- a/test_files/test_plugin.py
+++ b/test_files/test_plugin.py
@@ -223,3 +223,7 @@ def test_on_page_markdown(plugin):
         "[^1]: First Author and Second Author. Test title. *Testing Journal*, 2019."
         in plugin.on_page_markdown(test_markdown, None, None, None)
     )
+
+    test_markdown = "This is a citation. [@test] This is another citation [@test2]\n\n \\bibliography"
+    # ensure there are two items in bibliography
+    assert "[^2]:" in plugin.on_page_markdown(test_markdown, None, None, None)


### PR DESCRIPTION
This PR fixes inline citation numbering using the new system. A bug caused all citations to be labeled as `1`. Thanks to @epogrebnyak for bringing this up in #107 