### PR TITLE
Fix duplicates in bibliography

### DIFF
--- a/src/mkdocs_bibtex/plugin.py
+++ b/src/mkdocs_bibtex/plugin.py
@@ -122,27 +122,29 @@ class BibTexPlugin(BasePlugin):
 
         # Deal with arithmatex fix at some point
 
-        # 1. First collect any unformated references
+        # 1. Extract the keys from the keyset
         entries = OrderedDict()
-        for key_set in cite_keys:
-            for key in key_set.strip().strip("]").strip("[").split(";"):
-                key = key.strip().strip("@")
-                if key not in self.all_references:
-                    entries[key] = self.bib_data.entries[key]
+        pairs = [
+            [key_set, key.strip().strip("@")]
+            for key_set in cite_keys
+            for key in key_set.strip().strip("]").strip("[").split(";")
+        ]
+        keys = list(OrderedDict.fromkeys([k for _,k in pairs]).keys())
+        numbers = {k: str(n+1) for n,k in enumerate(keys)}
 
-        # 2. Format entries
+        # 2. Collect any unformatted reference keys
+        for _, key in pairs:
+            if key not in self.all_references:
+                entries[key] = self.bib_data.entries[key]
+
+        # 3. Format entries
         if self.csl_file:
             self.all_references.update(format_pandoc(entries, self.csl_file))
         else:
             self.all_references.update(format_simple(entries))
 
-        # 3. Construct quads
-        quads = []
-        for n, key_set in enumerate(cite_keys):
-            for key in key_set.strip().strip("]").strip("[").split(";"):
-                key = key.strip().strip("@")
-                quads.append((key_set, key, str(n + 1), self.all_references[key]))
-
+        # 4. Construct quads
+        quads = [(key_set, key, numbers[key], self.all_references[key]) for key_set, key in pairs]
         return quads
 
     @property

--- a/src/mkdocs_bibtex/plugin.py
+++ b/src/mkdocs_bibtex/plugin.py
@@ -129,8 +129,8 @@ class BibTexPlugin(BasePlugin):
             for key_set in cite_keys
             for key in key_set.strip().strip("]").strip("[").split(";")
         ]
-        keys = list(OrderedDict.fromkeys([k for _,k in pairs]).keys())
-        numbers = {k: str(n+1) for n,k in enumerate(keys)}
+        keys = list(OrderedDict.fromkeys([k for _, k in pairs]).keys())
+        numbers = {k: str(n + 1) for n, k in enumerate(keys)}
 
         # 2. Collect any unformatted reference keys
         for _, key in pairs:
@@ -144,7 +144,10 @@ class BibTexPlugin(BasePlugin):
             self.all_references.update(format_simple(entries))
 
         # 4. Construct quads
-        quads = [(key_set, key, numbers[key], self.all_references[key]) for key_set, key in pairs]
+        quads = [
+            (key_set, key, numbers[key], self.all_references[key])
+            for key_set, key in pairs
+        ]
         return quads
 
     @property

--- a/src/mkdocs_bibtex/utils.py
+++ b/src/mkdocs_bibtex/utils.py
@@ -142,7 +142,6 @@ def insert_citation_keys(citation_quads, markdown):
 
     # Renumber quads if using numbers for citation links
 
-
     grouped_quads = [list(g) for _, g in groupby(citation_quads, key=lambda x: x[0])]
     for quad_group in grouped_quads:
         full_citation = quad_group[0][0]  # the first key in the whole citation

--- a/src/mkdocs_bibtex/utils.py
+++ b/src/mkdocs_bibtex/utils.py
@@ -124,7 +124,7 @@ def find_cite_keys(markdown):
 
     cite_regex = re.compile(r"(\[(?:@\w+;{0,1}\s*)+\])")
     cite_keys = cite_regex.findall(markdown)
-    return list(cite_keys)
+    return list(OrderedDict.fromkeys(cite_keys).keys())
 
 
 def insert_citation_keys(citation_quads, markdown):

--- a/src/mkdocs_bibtex/utils.py
+++ b/src/mkdocs_bibtex/utils.py
@@ -141,11 +141,7 @@ def insert_citation_keys(citation_quads, markdown):
     """
 
     # Renumber quads if using numbers for citation links
-    if all(quad[2].isnumeric() for quad in citation_quads):
-        citation_quads = [
-            (quad[0], quad[1], str(n + 1), quad[2])
-            for n, quad in enumerate(citation_quads)
-        ]
+
 
     grouped_quads = [list(g) for _, g in groupby(citation_quads, key=lambda x: x[0])]
     for quad_group in grouped_quads:

--- a/test_files/test_plugin.py
+++ b/test_files/test_plugin.py
@@ -75,7 +75,7 @@ def test_format_citations(plugin):
         (
             "[@test; @test2]",
             "test2",
-            "1",
+            "2",
             "First Author and Second Author. Test Title (TT). *Testing Journal (TJ)*, 2019.",
         ),
     ] == plugin.format_citations(["[@test; @test2]"])

--- a/test_files/test_plugin.py
+++ b/test_files/test_plugin.py
@@ -224,6 +224,17 @@ def test_on_page_markdown(plugin):
         in plugin.on_page_markdown(test_markdown, None, None, None)
     )
 
-    test_markdown = "This is a citation. [@test] This is another citation [@test2]\n\n \\bibliography"
+    test_markdown = "This is a citation. [@test2] This is another citation [@test]\n\n \\bibliography"
     # ensure there are two items in bibliography
+
     assert "[^2]:" in plugin.on_page_markdown(test_markdown, None, None, None)
+
+    # Ensure if an item is referenced multiple times, it only shows up as one reference
+    test_markdown = "This is a citation. [@test] This is another citation [@test]\n\n \\bibliography"
+
+    assert "[^2]" not in plugin.on_page_markdown(test_markdown, None, None, None)
+
+    # Ensure item only shows up once even if used in multiple places as both a compound and lone cite key
+    test_markdown = "This is a citation. [@test; @test2] This is another citation [@test]\n\n \\bibliography"
+
+    assert "[^3]" not in plugin.on_page_markdown(test_markdown, None, None, None)


### PR DESCRIPTION
This PR should fix an issue referenced in #110 causing duplicate entries in the bibliography. The root cause was not properly checking for unique cite_keys when performing the numbering resulting in the same key being "footnoted" multiple types.