### PR TITLE
Add default bibliography flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ The footnotes extension is how citations are linked for now.
 - `bib_file` - Name of your bibtex file. Either the absolute path or the path relative to `mkdocs.yml`
 - `bib_dir` - Directory for bibtex files to load, same as above for path resolution
 - `bib_command` - The command for your bibliography, defaults to `\bibliography`
+- `bib_by_default` - Automatically appends `bib_command` to every markdown page, defaults to `true`
 - `full_bib_command` - The command for your full bibliography, defaults to `\full_bibliography`
+- `full_bib_by_default` - Automatically appends `full_bib_command` to every markdown page, defaults to `false`
 - `csl_file` - Bibtex CSL file to format the citation with, defaults to None, using a built in plain format instead
 
 ## Usage
@@ -44,6 +46,6 @@ The footnotes extension is how citations are linked for now.
 In your markdown files:
 
 1. Add your citations as you would if you used pandoc, IE: `[@first_cite;@second_cite]`
-2. Add in `\bibliography` or whatever you set your `bib_command` to where you want your references.
+2. Add in `\bibliography` or whatever you set your `bib_command` to where you want your references (if `bib_by_default` is set to true this gets added automatically).
 3. Add in `\full_bibliography` or whatever you set your `full_bib_command` to where you want the full set of references. *Note*: This is not work just right since this plugin can't dictate the orer in which files are processed. The best way to ensure the file with the full bibliography gets processed last is to use numbers in front of file/folder names to enforce an order of processing, IE: `01_my_first_file.md`
 4. (Optional) Setup `csl_file` to control the citation text formatting.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ The footnotes extension is how citations are linked for now.
 - `bib_command` - The command for your bibliography, defaults to `\bibliography`
 - `bib_by_default` - Automatically appends `bib_command` to every markdown page, defaults to `true`
 - `full_bib_command` - The command for your full bibliography, defaults to `\full_bibliography`
-- `full_bib_by_default` - Automatically appends `full_bib_command` to every markdown page, defaults to `false`
 - `csl_file` - Bibtex CSL file to format the citation with, defaults to None, using a built in plain format instead
 
 ## Usage

--- a/src/mkdocs_bibtex/plugin.py
+++ b/src/mkdocs_bibtex/plugin.py
@@ -99,7 +99,7 @@ class BibTexPlugin(BasePlugin):
         bib_command = self.config.get("bib_command", "\\bibliography")
 
         if self.config.get("bib_by_default"):
-            markdown += f'\n{bib_command}'
+            markdown += f"\n{bib_command}"
 
         bibliography = format_bibliography(citation_quads)
         markdown = re.sub(
@@ -110,7 +110,7 @@ class BibTexPlugin(BasePlugin):
 
         # 5. Build the full Bibliography and insert into the text
         full_bib_command = self.config.get("full_bib_command", "\\full_bibliography")
-        
+
         markdown = re.sub(
             re.escape(full_bib_command),
             self.full_bibliography,

--- a/src/mkdocs_bibtex/plugin.py
+++ b/src/mkdocs_bibtex/plugin.py
@@ -27,8 +27,6 @@ class BibTexPlugin(BasePlugin):
         bib_by_default (bool): automatically appends bib_command to markdown pages
                                by default, defaults to true
         full_bib_command (string): command to place a full bibliography of all references
-        full_bib_by_default (bool): automatically appends full_bib_command to markdown
-                                    pages by default, defaults to false
         csl_file (string, optional): path to a CSL file, relative to mkdocs.yml.
     """
 
@@ -38,7 +36,6 @@ class BibTexPlugin(BasePlugin):
         ("bib_command", config_options.Type(str, default="\\bibliography")),
         ("bib_by_default", config_options.Type(bool, default=True)),
         ("full_bib_command", config_options.Type(str, default="\\full_bibliography")),
-        ("full_bib_by_default", config_options.Type(bool, default=False)),
         ("csl_file", config_options.File(exists=True, required=False)),
     ]
 
@@ -110,9 +107,6 @@ class BibTexPlugin(BasePlugin):
         )
 
         # 5. Build the full Bibliography and insert into the text
-        if self.config.get("full_bib_by_default"):
-            markdown += "\n" + self.config.get("full_bib_command", "\\full_bibliography")
-
         markdown = re.sub(
             re.escape(self.config.get("full_bib_command", "\\full_bibliography")),
             self.full_bibliography,

--- a/src/mkdocs_bibtex/plugin.py
+++ b/src/mkdocs_bibtex/plugin.py
@@ -96,19 +96,23 @@ class BibTexPlugin(BasePlugin):
         markdown = insert_citation_keys(citation_quads, markdown)
 
         # 4. Insert in the bibliopgrahy text into the markdown
+        bib_command = self.config.get("bib_command", "\\bibliography")
+
         if self.config.get("bib_by_default"):
-            markdown += "\n" + self.config.get("bib_command", "\\bibliography")
+            markdown += f'\n{bib_command}'
 
         bibliography = format_bibliography(citation_quads)
         markdown = re.sub(
-            re.escape(self.config.get("bib_command", "\\bibliography")),
+            re.escape(bib_command),
             bibliography,
             markdown,
         )
 
         # 5. Build the full Bibliography and insert into the text
+        full_bib_command = self.config.get("full_bib_command", "\\full_bibliography")
+        
         markdown = re.sub(
-            re.escape(self.config.get("full_bib_command", "\\full_bibliography")),
+            re.escape(full_bib_command),
             self.full_bibliography,
             markdown,
         )

--- a/src/mkdocs_bibtex/plugin.py
+++ b/src/mkdocs_bibtex/plugin.py
@@ -24,7 +24,11 @@ class BibTexPlugin(BasePlugin):
         bib_dir (string): path to a directory of bibtex files for entries
         bib_command (string): command to place a bibliography relevant to just that file
                               defaults to \bibliography
+        bib_by_default (bool): automatically appends bib_command to markdown pages
+                               by default, defaults to true
         full_bib_command (string): command to place a full bibliography of all references
+        full_bib_by_default (bool): automatically appends full_bib_command to markdown
+                                    pages by default, defaults to false
         csl_file (string, optional): path to a CSL file, relative to mkdocs.yml.
     """
 
@@ -32,7 +36,9 @@ class BibTexPlugin(BasePlugin):
         ("bib_file", config_options.File(exists=True, required=False)),
         ("bib_dir", config_options.Dir(exists=True, required=False)),
         ("bib_command", config_options.Type(str, default="\\bibliography")),
+        ("bib_by_default", config_options.Type(bool, default=True)),
         ("full_bib_command", config_options.Type(str, default="\\full_bibliography")),
+        ("full_bib_by_default", config_options.Type(bool, default=False)),
         ("csl_file", config_options.File(exists=True, required=False)),
     ]
 
@@ -93,6 +99,9 @@ class BibTexPlugin(BasePlugin):
         markdown = insert_citation_keys(citation_quads, markdown)
 
         # 4. Insert in the bibliopgrahy text into the markdown
+        if self.config.get("bib_by_default"):
+            markdown += "\n" + self.config.get("bib_command", "\\bibliography")
+
         bibliography = format_bibliography(citation_quads)
         markdown = re.sub(
             re.escape(self.config.get("bib_command", "\\bibliography")),
@@ -101,6 +110,9 @@ class BibTexPlugin(BasePlugin):
         )
 
         # 5. Build the full Bibliography and insert into the text
+        if self.config.get("full_bib_by_default"):
+            markdown += "\n" + self.config.get("full_bib_command", "\\full_bibliography")
+
         markdown = re.sub(
             re.escape(self.config.get("full_bib_command", "\\full_bibliography")),
             self.full_bibliography,

--- a/test_files/test_plugin.py
+++ b/test_files/test_plugin.py
@@ -218,7 +218,7 @@ def test_format_pandoc(entries):
 def test_on_page_markdown(plugin):
     plugin.on_config(plugin.config)
     # run test with bib_by_default set to False
-    plugin.config['bib_by_default'] = False
+    plugin.config["bib_by_default"] = False
 
     test_markdown = "This is a citation. [@test]\n\n \\bibliography"
 
@@ -233,11 +233,11 @@ def test_on_page_markdown(plugin):
     assert "[^2]:" in plugin.on_page_markdown(test_markdown, None, None, None)
 
     # ensure bib_by_default is working
-    plugin.config['bib_by_default'] = True
+    plugin.config["bib_by_default"] = True
     test_markdown = "This is a citation. [@test]"
 
     assert "[^1]:" in plugin.on_page_markdown(test_markdown, None, None, None)
-    plugin.config['bib_by_default'] = False
+    plugin.config["bib_by_default"] = False
 
     # Ensure if an item is referenced multiple times, it only shows up as one reference
     test_markdown = "This is a citation. [@test] This is another citation [@test]\n\n \\bibliography"

--- a/test_files/test_plugin.py
+++ b/test_files/test_plugin.py
@@ -217,6 +217,9 @@ def test_format_pandoc(entries):
 
 def test_on_page_markdown(plugin):
     plugin.on_config(plugin.config)
+    # run test with bib_by_default set to False
+    plugin.config['bib_by_default'] = False
+
     test_markdown = "This is a citation. [@test]\n\n \\bibliography"
 
     assert (
@@ -224,10 +227,17 @@ def test_on_page_markdown(plugin):
         in plugin.on_page_markdown(test_markdown, None, None, None)
     )
 
-    test_markdown = "This is a citation. [@test2] This is another citation [@test]\n\n \\bibliography"
     # ensure there are two items in bibliography
+    test_markdown = "This is a citation. [@test2] This is another citation [@test]\n\n \\bibliography"
 
     assert "[^2]:" in plugin.on_page_markdown(test_markdown, None, None, None)
+
+    # ensure bib_by_default is working
+    plugin.config['bib_by_default'] = True
+    test_markdown = "This is a citation. [@test]"
+
+    assert "[^1]:" in plugin.on_page_markdown(test_markdown, None, None, None)
+    plugin.config['bib_by_default'] = False
 
     # Ensure if an item is referenced multiple times, it only shows up as one reference
     test_markdown = "This is a citation. [@test] This is another citation [@test]\n\n \\bibliography"


### PR DESCRIPTION
Seemed a bit redundant to have to add the bib_command on every page, seeing as they don't render if no citations are present.