### PR TITLE
Update citekey regex to match bibtex specification

### DIFF
--- a/src/mkdocs_bibtex/utils.py
+++ b/src/mkdocs_bibtex/utils.py
@@ -150,7 +150,7 @@ def extract_cite_keys(cite_block):
     """
     Extract just the keys from a citation block
     """
-    cite_regex = re.compile(r"@(\w*)")
+    cite_regex = re.compile(r"@([\w:-]*)")
     cite_keys = re.findall(cite_regex, cite_block)
 
     return cite_keys


### PR DESCRIPTION
Addresses #130 and regex now follows the specification of BibTex https://www.bibtex.com/g/bibtex-format/#citekey
(All alphanumericals, `-`, `:` and `_` characters.)