### PR TITLE
Fix pandoc >2.11 reference formatting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,6 @@
 [run]
 omit = *test*
+
+[report]
+exclude_lines =
+    pragma: no cover

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -50,7 +50,7 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10']
         pandoc-version: [2.9.2, 2.14.0.3]
     runs-on: ${{ matrix.os }}
 

--- a/src/mkdocs_bibtex/__init__.py
+++ b/src/mkdocs_bibtex/__init__.py
@@ -4,6 +4,6 @@ from mkdocs_bibtex.plugin import BibTexPlugin
 
 try:
     __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+except DistributionNotFound:  # pragma: no cover
     # package is not installed
     pass

--- a/src/mkdocs_bibtex/plugin.py
+++ b/src/mkdocs_bibtex/plugin.py
@@ -67,7 +67,7 @@ class BibTexPlugin(BasePlugin):
                 bibfiles.append(self.config["bib_file"])
         elif self.config.get("bib_dir", None) is not None:
             bibfiles.extend(Path(self.config["bib_dir"]).glob("*.bib"))
-        else:
+        else:  # pragma: no cover
             raise Exception("Must supply a bibtex file or directory for bibtex files")
 
         # load bibliography data
@@ -87,7 +87,7 @@ class BibTexPlugin(BasePlugin):
 
         # Toggle whether or not to render citations inline (Requires CSL)
         self.cite_inline = self.config.get("cite_inline", False)
-        if self.cite_inline and not self.csl_file:
+        if self.cite_inline and not self.csl_file:  # pragma: no cover
             raise Exception("Must supply a CSL file in order to use cite_inline")
 
         return config

--- a/src/mkdocs_bibtex/utils.py
+++ b/src/mkdocs_bibtex/utils.py
@@ -75,11 +75,11 @@ def _convert_pandoc_new(bibtex_string, csl_path):
 
     markdown = " ".join(markdown.split("\n"))
     # Remove newlines from any generated span tag (non-capitalized words)
-    markdown = re.sub(r'<\/span>[\r\n]', '</span> ', markdown)
+    markdown = re.compile(r'<\/span>[\r\n]').sub('<\/span> ', markdown)
 
     citation_regex = re.compile(r"<span\s+class=\"csl-(?:left-margin|right-inline)\">(.+?)(?=<\/span>)<\/span>")
     try:
-        citation = citation_regex.findall(re.sub(r"[\r\n]", "", markdown))[1]
+        citation = citation_regex.findall(re.sub(r"(\r|\n)", "", markdown))[1]
     except IndexError:
         citation = markdown
     return citation.strip()
@@ -115,7 +115,7 @@ def _convert_pandoc_citekey(bibtex_string, csl_path, fullcite):
 
     # Return only the citation text (first line(s))
     # remove any extra linebreaks to accommodate large author names
-    markdown = re.sub(r'[\r\n]', '', markdown)
+    markdown = re.compile(r'[\r\n]').sub('', markdown)
     return markdown.split(":::")[0].strip()
 
 

--- a/src/mkdocs_bibtex/utils.py
+++ b/src/mkdocs_bibtex/utils.py
@@ -75,7 +75,7 @@ def _convert_pandoc_new(bibtex_string, csl_path):
 
     markdown = " ".join(markdown.split("\n"))
     # Remove newlines from any generated span tag (non-capitalized words)
-    markdown = re.compile(r'<\/span>[\r\n]').sub('<\/span> ', markdown)
+    markdown = re.compile(r'<\/span>[\r\n]').sub('</span> ', markdown)
 
     citation_regex = re.compile(r"<span\s+class=\"csl-(?:left-margin|right-inline)\">(.+?)(?=<\/span>)<\/span>")
     try:

--- a/src/mkdocs_bibtex/utils.py
+++ b/src/mkdocs_bibtex/utils.py
@@ -64,7 +64,7 @@ def _convert_pandoc_new(bibtex_string, csl_path):
     """
     markdown = pypandoc.convert_text(
         source=bibtex_string,
-        to="markdown-citations",
+        to="markdown_strict",
         format="bibtex",
         extra_args=[
             "--citeproc",
@@ -73,13 +73,13 @@ def _convert_pandoc_new(bibtex_string, csl_path):
         ],
     )
 
-    # This should cut off the pandoc preamble and ending triple colons
-    markdown = " ".join(markdown.split("\n")[2:-2])
+    markdown = " ".join(markdown.split("\n"))
+    # Remove newlines from any generated span tag (non-capitalized words)
+    markdown = re.sub(r'<\/span>[\r\n]', '</span> ', markdown)
 
-    citation_regex = re.compile(r"\{\.csl-left-margin\}\[(.*)\]\{\.csl-right-inline\}")
+    citation_regex = re.compile(r"<span\s+class=\"csl-(?:left-margin|right-inline)\">(.+?)(?=<\/span>)<\/span>")
     try:
-
-        citation = citation_regex.findall(markdown.replace("\n", " "))[0]
+        citation = citation_regex.findall(re.sub(r"[\r\n]", "", markdown))[1]
     except IndexError:
         citation = markdown
     return citation.strip()
@@ -115,7 +115,8 @@ def _convert_pandoc_citekey(bibtex_string, csl_path, fullcite):
 
     # Return only the citation text (first line(s))
     # remove any extra linebreaks to accommodate large author names
-    return markdown.split(":::")[0].replace("\r\n", "").replace("\n", "").strip()
+    markdown = re.sub(r'[\r\n]', '', markdown)
+    return markdown.split(":::")[0].strip()
 
 
 def _convert_pandoc_legacy(bibtex_string, csl_path):
@@ -261,7 +262,7 @@ def tempfile_from_url(url, suffix):
     for i in range(3):
         try:
             dl = requests.get(url)
-            if dl.status_code != 200:
+            if dl.status_code != 200:  # pragma: no cover
                 raise RuntimeError(f"Couldn't download the url: {url}.\n Status Code: {dl.status_code}")
 
             file = tempfile.NamedTemporaryFile(mode='w', suffix=suffix, delete=False)
@@ -269,6 +270,6 @@ def tempfile_from_url(url, suffix):
             file.close()
             return file.name
 
-        except requests.exceptions.RequestException:
+        except requests.exceptions.RequestException:  # pragma: no cover
             pass
-    raise RuntimeError(f"Couldn't successfully download the url: {url}")
+    raise RuntimeError(f"Couldn't successfully download the url: {url}")  # pragma: no cover


### PR DESCRIPTION
Turns out these were broken, apt has been stuck on 2.5 so never noticed.

`markdown-citations` would spit out `[wOrd]{.nocase}` on words without first-letter capitalization and include the `:::` preamble. `markdown_strict` appears to be more reliable.

Edit: Removed Python 3.6 from testing, as it appears to be depreciated.