### PR TITLE
Fix Tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         python setup.py sdist
 
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@main
       with:
         user: __token__
         password: ${{ secrets.PYPY_API_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -50,7 +50,7 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10',3.11]
         pandoc-version: [2.9.2, 2.14.0.3]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -62,7 +62,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - uses: r-lib/actions/setup-pandoc@main
+    - uses: r-lib/actions/setup-pandoc@v2
       with:
         pandoc-version: ${{ matrix.pandoc-version }}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,11 +3,11 @@ name: testing
 on:
   push:
     branches:
-      - master
+      - main
 
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   lint:
@@ -62,7 +62,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - uses: r-lib/actions/setup-pandoc@master
+    - uses: r-lib/actions/setup-pandoc@main
       with:
         pandoc-version: ${{ matrix.pandoc-version }}
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![testing](https://github.com/shyamd/mkdocs-bibtex/workflows/testing/badge.svg)](https://github.com/shyamd/mkdocs-bibtex/actions?query=workflow%3Atesting)
-[![codecov](https://codecov.io/gh/shyamd/mkdocs-bibtex/branch/master/graph/badge.svg)](https://codecov.io/gh/shyamd/mkdocs-bibtex)
+[![codecov](https://codecov.io/gh/shyamd/mkdocs-bibtex/branch/main/graph/badge.svg)](https://codecov.io/gh/shyamd/mkdocs-bibtex)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/shyamd/mkdocs-bibtex.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/shyamd/mkdocs-bibtex/context:python)
 
 # mkdocs-bibtex

--- a/test_files/test.bib
+++ b/test_files/test.bib
@@ -29,3 +29,13 @@
   keywords = {attention,bees,drosophila,insects},
   pmid = {27436727}
 }
+
+@article{test_citavi,
+  title={{Test Title (TT)}},
+  author={Author, First and Author, Second},
+  journal={Testing Journal (TJ)},
+  volume={1},
+  year={2019},
+  publisher={Test_Publisher (TP)},
+  url = {\url{https://doi.org/10.21577/0103-5053.20190253}}
+}

--- a/test_files/test_plugin.py
+++ b/test_files/test_plugin.py
@@ -34,13 +34,15 @@ def entries():
 
 
 def test_bibtex_loading_bibfile(plugin):
-    assert len(plugin.bib_data.entries) == 3
+    assert len(plugin.bib_data.entries) == 4
 
 
 def test_bibtex_loading_bib_url():
     plugin = BibTexPlugin()
     plugin.load_config(
-        options={"bib_file": "https://raw.githubusercontent.com/shyamd/mkdocs-bibtex/master/test_files/test.bib"},
+        options={
+            "bib_file": "https://raw.githubusercontent.com/shyamd/mkdocs-bibtex/master/test_files/test.bib"
+        },
         config_file_path=test_files_dir,
     )
 
@@ -100,6 +102,14 @@ def test_format_citations(plugin):
         "Benjamin L. De Bivort and Bruno Van Swinderen. Evidence for selective attention in the insect brain. *Current Opinion in Insect Science*, 15:1–7, 2016. [doi:10.1016/j.cois.2016.02.007](https://doi.org/10.1016/j.cois.2016.02.007).",  # noqa: E501
     ) == plugin.format_citations(["[@Bivort2016]"])[0]
 
+    # Test \url embedding
+    assert (
+        "[@test_citavi]",
+        "test_citavi",
+        "1",
+        "First Author and Second Author. Test Title (TT). *Testing Journal (TJ)*, 2019. URL: [\\\\url\\{https://doi.org/10.21577/0103\\-5053.20190253\\}](\\url{https://doi.org/10.21577/0103-5053.20190253}).",  # noqa: E501
+    ) == plugin.format_citations(["[@test_citavi]"])[0]
+
     # Test formatting using a CSL style
     plugin.csl_file = os.path.join(test_files_dir, "nature.csl")
     assert (
@@ -125,11 +135,21 @@ def test_format_citations(plugin):
         "First Author and Second Author. Test title. *Testing Journal*, 2019.",
     ) == plugin.format_citations(["[@test]"])[0]
 
+    assert (
+        "[@test_citavi]",
+        "test_citavi",
+        "1",
+        "First Author and Second Author. Test Title (TT). *Testing Journal (TJ)*, 2019. URL: [\\\\url\\{https://doi.org/10.21577/0103\\-5053.20190253\\}](\\url{https://doi.org/10.21577/0103-5053.20190253}).",  # noqa: E501
+    ) == plugin.format_citations(["[@test_citavi]"])[0]
+
 
 def test_find_cite_blocks():
     assert find_cite_blocks("[@test]") == ["[@test]"]
     assert find_cite_blocks("[@test; @test2]") == ["[@test; @test2]"]
-    assert find_cite_blocks("[@test]\n [@test; @test2]") == ["[@test]", "[@test; @test2]"]
+    assert find_cite_blocks("[@test]\n [@test; @test2]") == [
+        "[@test]",
+        "[@test; @test2]",
+    ]
     # Suppressed authors
     assert find_cite_blocks("[-@test]") == ["[-@test]"]
     # Affixes
@@ -139,6 +159,8 @@ def test_find_cite_blocks():
     assert find_cite_blocks("[see -@test, p. 15]") == ["[see -@test, p. 15]"]
     # Invalid blocks
     assert find_cite_blocks("[ @test]") is not True
+    # Citavi . format
+    assert find_cite_blocks("[@Bermudez.2020]") == ["[@Bermudez.2020]"]
 
 
 def test_insert_citation_keys():
@@ -263,7 +285,9 @@ def test_on_page_markdown(plugin):
     # ensure nonexistant citekeys are removed correctly (not replaced)
     test_markdown = "A non-existant citekey. [@i_do_not_exist]"
 
-    assert "[@i_do_not_exist]" in plugin.on_page_markdown(test_markdown, None, None, None)
+    assert "[@i_do_not_exist]" in plugin.on_page_markdown(
+        test_markdown, None, None, None
+    )
 
     # Ensure if an item is referenced multiple times, it only shows up as one reference
     test_markdown = "This is a citation. [@test] This is another citation [@test]\n\n \\bibliography"
@@ -278,7 +302,9 @@ def test_on_page_markdown(plugin):
 
 def test_inline_citations(plugin):
     plugin.config["bib_file"] = os.path.join(test_files_dir, "test.bib")
-    plugin.config["csl_file"] = os.path.join(test_files_dir, "springer-basic-author-date.csl")
+    plugin.config["csl_file"] = os.path.join(
+        test_files_dir, "springer-basic-author-date.csl"
+    )
     plugin.config["cite_inline"] = True
 
     plugin.on_config(plugin.config)
@@ -290,66 +316,81 @@ def test_inline_citations(plugin):
 
     # Ensure inline citation works
     quads = [("[@test]", None, "1", None)]
-    test_markdown = 'Hello[@test]'
+    test_markdown = "Hello[@test]"
     result = "Hello (Author and Author 2019)[^1]"
-    assert result == insert_citation_keys(quads, test_markdown, plugin.csl_file,
-                                          plugin.bib_data.to_string("bibtex"))
+    assert result == insert_citation_keys(
+        quads, test_markdown, plugin.csl_file, plugin.bib_data.to_string("bibtex")
+    )
 
     # Ensure suppressed authors works
     quads = [("[-@test]", None, "1", None)]
-    test_markdown = 'Suppressed [-@test]'
+    test_markdown = "Suppressed [-@test]"
     result = "Suppressed (2019)[^1]"
-    assert result == insert_citation_keys(quads, test_markdown, plugin.csl_file,
-                                          plugin.bib_data.to_string("bibtex"))
+    assert result == insert_citation_keys(
+        quads, test_markdown, plugin.csl_file, plugin.bib_data.to_string("bibtex")
+    )
 
     # Ensure affixes work
     quads = [("[see @test]", None, "1", None)]
-    test_markdown = 'Hello[see @test]'
+    test_markdown = "Hello[see @test]"
     result = "Hello (see Author and Author 2019)[^1]"
-    assert result == insert_citation_keys(quads, test_markdown, plugin.csl_file,
-                                          plugin.bib_data.to_string("bibtex"))
+    assert result == insert_citation_keys(
+        quads, test_markdown, plugin.csl_file, plugin.bib_data.to_string("bibtex")
+    )
 
     quads = [("[@test, p. 123]", None, "1", None)]
-    test_markdown = '[@test, p. 123]'
+    test_markdown = "[@test, p. 123]"
     result = " (Author and Author 2019, p. 123)[^1]"
-    assert result == insert_citation_keys(quads, test_markdown, plugin.csl_file,
-                                          plugin.bib_data.to_string("bibtex"))
+    assert result == insert_citation_keys(
+        quads, test_markdown, plugin.csl_file, plugin.bib_data.to_string("bibtex")
+    )
 
     # Combined
     quads = [("[see @test, p. 123]", None, "1", None)]
-    test_markdown = 'Hello[see @test, p. 123]'
+    test_markdown = "Hello[see @test, p. 123]"
     result = "Hello (see Author and Author 2019, p. 123)[^1]"
-    assert result == insert_citation_keys(quads, test_markdown, plugin.csl_file,
-                                          plugin.bib_data.to_string("bibtex"))
+    assert result == insert_citation_keys(
+        quads, test_markdown, plugin.csl_file, plugin.bib_data.to_string("bibtex")
+    )
 
     # Combined, suppressed author
     quads = [("[see -@test, p. 123]", None, "1", None)]
-    test_markdown = 'Suppressed [see -@test, p. 123]'
+    test_markdown = "Suppressed [see -@test, p. 123]"
     result = "Suppressed (see 2019, p. 123)[^1]"
-    assert result == insert_citation_keys(quads, test_markdown, plugin.csl_file,
-                                          plugin.bib_data.to_string("bibtex"))
+    assert result == insert_citation_keys(
+        quads, test_markdown, plugin.csl_file, plugin.bib_data.to_string("bibtex")
+    )
 
     # Ensure multi references work
-    quads = [("[@test; @Bivort2016]", None, "1", None),
-             ("[@test; @Bivort2016]", None, "2", None)]
-    test_markdown = '[@test; @Bivort2016]'
+    quads = [
+        ("[@test; @Bivort2016]", None, "1", None),
+        ("[@test; @Bivort2016]", None, "2", None),
+    ]
+    test_markdown = "[@test; @Bivort2016]"
     # CSL defines the order, this ordering is therefore expected with springer.csl
     result = " (De Bivort and Van Swinderen 2016; Author and Author 2019)[^1][^2]"
-    assert result == insert_citation_keys(quads, test_markdown, plugin.csl_file,
-                                          plugin.bib_data.to_string("bibtex"))
+    assert result == insert_citation_keys(
+        quads, test_markdown, plugin.csl_file, plugin.bib_data.to_string("bibtex")
+    )
 
-    quads = [("[@test, p. 12; @Bivort2016, p. 15]", None, "1", None),
-             ("[@test, p. 12; @Bivort2016, p. 15]", None, "2", None)]
-    test_markdown = '[@test, p. 12; @Bivort2016, p. 15]'
+    quads = [
+        ("[@test, p. 12; @Bivort2016, p. 15]", None, "1", None),
+        ("[@test, p. 12; @Bivort2016, p. 15]", None, "2", None),
+    ]
+    test_markdown = "[@test, p. 12; @Bivort2016, p. 15]"
     # CSL defines the order, this ordering is therefore expected with springer.csl
     result = " (De Bivort and Van Swinderen 2016, p. 15; Author and Author 2019, p. 12)[^1][^2]"
-    assert result == insert_citation_keys(quads, test_markdown, plugin.csl_file,
-                                          plugin.bib_data.to_string("bibtex"))
+    assert result == insert_citation_keys(
+        quads, test_markdown, plugin.csl_file, plugin.bib_data.to_string("bibtex")
+    )
 
     # Ensure multiple inline references works
-    quads = [("[@test]", None, "1", None),
-             ("[see @Bivort2016, p. 123]", None, "2", None)]
-    test_markdown = 'Hello[@test] World [see @Bivort2016, p. 123]'
+    quads = [
+        ("[@test]", None, "1", None),
+        ("[see @Bivort2016, p. 123]", None, "2", None),
+    ]
+    test_markdown = "Hello[@test] World [see @Bivort2016, p. 123]"
     result = "Hello (Author and Author 2019)[^1] World (see De Bivort and Van Swinderen 2016, p. 123)[^2]"
-    assert result == insert_citation_keys(quads, test_markdown, plugin.csl_file,
-                                          plugin.bib_data.to_string("bibtex"))
+    assert result == insert_citation_keys(
+        quads, test_markdown, plugin.csl_file, plugin.bib_data.to_string("bibtex")
+    )

--- a/test_files/test_plugin.py
+++ b/test_files/test_plugin.py
@@ -41,7 +41,7 @@ def test_bibtex_loading_bib_url():
     plugin = BibTexPlugin()
     plugin.load_config(
         options={
-            "bib_file": "https://raw.githubusercontent.com/shyamd/mkdocs-bibtex/master/test_files/test.bib"
+            "bib_file": "https://raw.githubusercontent.com/shyamd/mkdocs-bibtex/main/test_files/test.bib"
         },
         config_file_path=test_files_dir,
     )


### PR DESCRIPTION
This PR has been modified to be about testing first as the tests have been broken for some time due to the `setup-pandoc` action deleting their `main` branch and using versioned branches instead. 

Old PR Text:
```
This PR currently just introduces some tests for Citavi style bib-entries and citation formats. 
```