### PR TITLE
(patch): fix auto-merge

### DIFF
--- a/.github/workflows/post-process.yml
+++ b/.github/workflows/post-process.yml
@@ -19,7 +19,7 @@ jobs:
         name: Merge me!
         uses: ridedott/merge-me-action@v2
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SEMVER_BUMP_TOKEN }}
 
   auto-gen-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hopefully fix the auto merge by using the PAT used for repo access rather than the read-only Github Token.