### PR TITLE
Fix setuptools dependency for poetry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 setup(
     name="mkdocs-bibtex",
     use_scm_version=True,
-    setup_requires=["setuptools_scm"],
+    setup_requires=["setuptools_scm", "setuptools"],
     description="An MkDocs plugin that enables managing citations with BibTex",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This ensures `setuptools` is in the `setup_requires` list to ensure non-setuptools based packages can still use this package. 