### PR TITLE
fix(#173): add config option to prevent clobbering user's numbered fo…

### DIFF
--- a/src/mkdocs_bibtex/plugin.py
+++ b/src/mkdocs_bibtex/plugin.py
@@ -94,6 +94,8 @@ class BibTexPlugin(BasePlugin):
         if "{number}" not in self.config.get("footnote_format"):
             raise Exception("Must include `{number}` placeholder in footnote_format")
 
+        self.footnote_format = self.config.get("footnote_format")
+
         return config
 
     def on_page_markdown(self, markdown, page, config, files):
@@ -155,7 +157,8 @@ class BibTexPlugin(BasePlugin):
         return markdown
 
     def format_footnote_key(self, number):
-        """create footnote key based on footnote_format
+        """
+        Create footnote key based on footnote_format
 
         Args:
             number (int): citation number
@@ -163,7 +166,7 @@ class BibTexPlugin(BasePlugin):
         Returns:
             formatted footnote
         """
-        return self.config.get("footnote_format").format(number=number)
+        return self.footnote_format.format(number=number)
 
     def format_citations(self, cite_keys):
         """

--- a/src/mkdocs_bibtex/plugin.py
+++ b/src/mkdocs_bibtex/plugin.py
@@ -43,6 +43,7 @@ class BibTexPlugin(BasePlugin):
         ("full_bib_command", config_options.Type(str, default="\\full_bibliography")),
         ("csl_file", config_options.Type(str, default="")),
         ("cite_inline", config_options.Type(bool, default=False)),
+        ("footnote_format", config_options.Type(str, default="{number}")),
     ]
 
     def __init__(self):
@@ -90,6 +91,9 @@ class BibTexPlugin(BasePlugin):
         if self.cite_inline and not self.csl_file:  # pragma: no cover
             raise Exception("Must supply a CSL file in order to use cite_inline")
 
+        if "{number}" not in self.config.get("footnote_format"):
+            raise Exception("Must include `{number}` placeholder in footnote_format")
+
         return config
 
     def on_page_markdown(self, markdown, page, config, files):
@@ -100,9 +104,9 @@ class BibTexPlugin(BasePlugin):
         1. Finds all cite keys (may include multiple citation references)
         2. Convert all cite keys to citation quads:
             (full cite key,
-            induvidual cite key,
+            individual cite key,
             citation key in corresponding style,
-            citation for induvidual cite key)
+            citation for individual cite key)
         3. Insert formatted cite keys into text
         4. Insert the bibliography into the markdown
         5. Insert the full bibliograph into the markdown
@@ -150,6 +154,17 @@ class BibTexPlugin(BasePlugin):
 
         return markdown
 
+    def format_footnote_key(self, number):
+        """create footnote key based on footnote_format
+
+        Args:
+            number (int): citation number
+
+        Returns:
+            formatted footnote
+        """
+        return self.config.get("footnote_format").format(number=number)
+
     def format_citations(self, cite_keys):
         """
         Formats references into citation quads and adds them to the global registry
@@ -189,7 +204,12 @@ class BibTexPlugin(BasePlugin):
 
         # 4. Construct quads
         quads = [
-            (cite_block, key, numbers[key], self.all_references[key])
+            (
+                cite_block,
+                key,
+                self.format_footnote_key(numbers[key]),
+                self.all_references[key],
+            )
             for cite_block, key in pairs
         ]
 
@@ -204,7 +224,10 @@ class BibTexPlugin(BasePlugin):
 
         bibliography = []
         for number, (key, citation) in enumerate(self.all_references.items()):
-            bibliography_text = "[^{}]: {}".format(number, citation)
+            bibliography_text = "[^{}]: {}".format(
+                number,
+                citation,
+            )
             bibliography.append(bibliography_text)
 
         return "\n".join(bibliography)

--- a/test_files/test_features.py
+++ b/test_files/test_features.py
@@ -331,3 +331,18 @@ def test_multi_reference(plugin_advanced_pandoc):
     assert result == insert_citation_keys(
         quads, test_markdown, plugin.csl_file, plugin.bib_data.to_string("bibtex")
     )
+
+
+def test_custom_footnote_formatting(plugin):
+
+    assert plugin.format_footnote_key(1) == "1"
+    plugin.footnote_format = "Test Format {number}"
+    assert plugin.format_footnote_key(1) == "Test Format 1"
+
+    plugin.csl_file = os.path.join(test_files_dir, "nature.csl")
+    assert (
+        "[@test]",
+        "test",
+        "Test Format 1",
+        "Author, F. & Author, S. Test title. *Testing Journal* **1**, (2019).",
+    ) == plugin.format_citations(["[@test]"])[0]

--- a/test_files/test_plugin.py
+++ b/test_files/test_plugin.py
@@ -91,3 +91,18 @@ def test_on_page_markdown(plugin):
     test_markdown = "This is a citation. [@test; @test2] This is another citation [@test]\n\n \\bibliography"
 
     assert "[^3]" not in plugin.on_page_markdown(test_markdown, None, None, None)
+
+
+def test_footnote_formatting_config(plugin):
+    """
+    This function tests to ensure footnote formatting configuration is working properly
+    """
+    # Test to make sure the config enforces {number} in the format
+    bad_plugin = BibTexPlugin()
+    bad_plugin.load_config(
+        options={"footnote_format": ""},
+        config_file_path=test_files_dir,
+    )
+
+    with pytest.raises(Exception):
+        bad_plugin.on_config(bad_plugin.config)


### PR DESCRIPTION
…otnotes

Exposes a new config option to define the footnote format:
```yaml
... 
plugins:
  - search
  - bibtex:
      bib_file: "refs.bib"
      footnote_format: "ref{number}" # default "{number}"
...
```