### PR TITLE
Cache pandoc-citekey

### DIFF
--- a/src/mkdocs_bibtex/utils.py
+++ b/src/mkdocs_bibtex/utils.py
@@ -3,6 +3,7 @@ import re
 import requests
 import tempfile
 from collections import OrderedDict
+from functools import lru_cache
 from itertools import groupby
 from pathlib import Path
 
@@ -100,6 +101,7 @@ def _convert_pandoc_new(bibtex_string, csl_path):
     return citation.strip()
 
 
+@lru_cache(maxsize=1024)
 def _convert_pandoc_citekey(bibtex_string, csl_path, fullcite):
     """
     Uses pandoc to convert a markdown citation key reference


### PR DESCRIPTION
As a followup to #238, this PR shaves off a few more seconds from the build by unobtrusively using `functools.lru_cache` to memoize the rendering of citekeys. For our 32 bib entries, and ~30 sec build this cuts time down by 8-10%.

The size of 1024 is of course arbitrary, but I assume more than enough for the majority of projects. Alternatively one can set it to `None` and let the cache grow indefinitely (which shouldn't be a problem in principle, but better safe than sorry :)