### PR TITLE
Skip building bib_data if files are older than config time (for mkdocs serve)

### DIFF
--- a/src/mkdocs_bibtex/plugin.py
+++ b/src/mkdocs_bibtex/plugin.py
@@ -92,6 +92,9 @@ class BibTexPlugin(BasePlugin):
                 log.info("BibTexPlugin: No changes in bibfiles.")
                 return config
         
+        # Clear references on reconfig
+        self.all_references = OrderedDict()
+        
         self.bib_data = BibliographyData(entries=refs)
 
         # Set CSL from either url or path (or empty)

--- a/src/mkdocs_bibtex/plugin.py
+++ b/src/mkdocs_bibtex/plugin.py
@@ -86,9 +86,9 @@ class BibTexPlugin(BasePlugin):
             bibdata = parse_file(bibfile)
             refs.update(bibdata.entries)
 
-        if self.configured:
+        if hasattr(self,"last_configured"):
             # Skip rebuilding bib data if all files are older than the initial config
-            if all(Path(bibfile).stat().st_mtime < self.configured for bibfile in bibfiles):
+            if all(Path(bibfile).stat().st_mtime < self.last_configured for bibfile in bibfiles):
                 log.info("BibTexPlugin: No changes in bibfiles.")
                 return config
 
@@ -114,7 +114,7 @@ class BibTexPlugin(BasePlugin):
 
         self.footnote_format = self.config.get("footnote_format")
 
-        self.configured = time.time()
+        self.last_configured = time.time()
         return config
 
     def on_page_markdown(self, markdown, page, config, files):

--- a/src/mkdocs_bibtex/plugin.py
+++ b/src/mkdocs_bibtex/plugin.py
@@ -1,4 +1,5 @@
 import re
+import time
 import validators
 from collections import OrderedDict
 from pathlib import Path
@@ -51,6 +52,11 @@ class BibTexPlugin(BasePlugin):
         self.bib_data = None
         self.all_references = OrderedDict()
         self.unescape_for_arithmatex = False
+        self.configured = False
+
+    def on_startup(self, *, command, dirty):
+        """ Having on_startup() tells mkdocs to keep the plugin object upon rebuilds"""
+        pass
 
     def on_config(self, config):
         """
@@ -80,6 +86,12 @@ class BibTexPlugin(BasePlugin):
             bibdata = parse_file(bibfile)
             refs.update(bibdata.entries)
 
+        if self.configured:
+            # Skip rebuilding bib data if all files are older than the initial config
+            if all(Path(bibfile).stat().st_mtime < self.configured for bibfile in bibfiles):
+                log.info("BibTexPlugin: No changes in bibfiles, returning config as is")
+            return config
+        
         self.bib_data = BibliographyData(entries=refs)
 
         # Set CSL from either url or path (or empty)
@@ -99,6 +111,7 @@ class BibTexPlugin(BasePlugin):
 
         self.footnote_format = self.config.get("footnote_format")
 
+        self.configured = time.time()
         return config
 
     def on_page_markdown(self, markdown, page, config, files):

--- a/src/mkdocs_bibtex/plugin.py
+++ b/src/mkdocs_bibtex/plugin.py
@@ -89,8 +89,8 @@ class BibTexPlugin(BasePlugin):
         if self.configured:
             # Skip rebuilding bib data if all files are older than the initial config
             if all(Path(bibfile).stat().st_mtime < self.configured for bibfile in bibfiles):
-                log.info("BibTexPlugin: No changes in bibfiles, returning config as is")
-            return config
+                log.info("BibTexPlugin: No changes in bibfiles.")
+                return config
         
         self.bib_data = BibliographyData(entries=refs)
 

--- a/src/mkdocs_bibtex/plugin.py
+++ b/src/mkdocs_bibtex/plugin.py
@@ -91,10 +91,10 @@ class BibTexPlugin(BasePlugin):
             if all(Path(bibfile).stat().st_mtime < self.configured for bibfile in bibfiles):
                 log.info("BibTexPlugin: No changes in bibfiles.")
                 return config
-        
+
         # Clear references on reconfig
         self.all_references = OrderedDict()
-        
+
         self.bib_data = BibliographyData(entries=refs)
 
         # Set CSL from either url or path (or empty)

--- a/test_files/test_features.py
+++ b/test_files/test_features.py
@@ -35,6 +35,7 @@ def plugin():
     return plugin
 
 
+
 @pytest.fixture
 def plugin_advanced_pandoc(plugin):
     """
@@ -52,6 +53,7 @@ def plugin_advanced_pandoc(plugin):
     )
     plugin.config["cite_inline"] = True
 
+    delattr(plugin,"last_configured")
     plugin.on_config(plugin.config)
 
     return plugin


### PR DESCRIPTION
This PR is a continuation to #238. 

* It uses [`on_startup()`](https://www.mkdocs.org/dev-guide/plugins/#on_startup) to avoid unloading the plugin when using `mkdocs serve`.
* It avoids rendering the bibtex for all references during `on_config()` by storing the `time()` of the first run, then checking the timestamps of the bibtex files passed by the user. If any file is newer all refs are read again.

The speedup is only noticeable after merging #238, but with both PRs together, our re-build using `mkdocs serve` goes from ~41secs to ~25 secs, or a 40% total reduction in build time. This makes working on documentation much nicer :) 