### PR TITLE
fix: Fixed warning related to deprecated mkdocs logging function

### DIFF
--- a/src/mkdocs_bibtex/utils.py
+++ b/src/mkdocs_bibtex/utils.py
@@ -6,17 +6,24 @@ from collections import OrderedDict
 from functools import lru_cache
 from itertools import groupby
 from pathlib import Path
+from packaging.version import Version
 
+import mkdocs
 import pypandoc
-from mkdocs.utils import warning_filter
 
 from pybtex.backends.markdown import Backend as MarkdownBackend
 from pybtex.database import BibliographyData
 from pybtex.style.formatting.plain import Style as PlainStyle
 
-
+# Grab a logger
 log = logging.getLogger("mkdocs.plugins.mkdocs-bibtex")
-log.addFilter(warning_filter)
+
+# Add the warning filter only if the version is lower than 1.2
+# Filter doesn't do anything since that version
+MKDOCS_LOG_VERSION = '1.2'
+if Version(mkdocs.__version__) < Version(MKDOCS_LOG_VERSION):
+    from mkdocs.utils import warning_filter
+    log.addFilter(warning_filter)
 
 
 def format_simple(entries):


### PR DESCRIPTION
The `warning_filter` function from MkDocs is no longer working since version 1.2.
Using the function results in a warning during the building of an MkDocs website using the bibtex pluging.

I added a condition that checks which version of MkDocs the user is running and calls the `warning_filter` accordingly.
This removes the warning on newer versions of MkDocs.

The implementation is based on: https://github.com/fralau/mkdocs-macros-plugin/commit/979a9766d5d5d11938849d284d4396023efe021b