### PR TITLE
[feat]: Support for global bibliographies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,11 @@ setup(
         "pypandoc>=1.5",
         "requests>=2.8.1",
         "validators>=0.19.0",
-        "setuptools>=68.0.0"
+        "setuptools>=68.0.0",
     ],
     tests_require=["pytest"],
     packages=find_packages("src"),
     package_dir={"": "src"},
     entry_points={"mkdocs.plugins": ["bibtex = mkdocs_bibtex.plugin:BibTexPlugin"]},
+    version="2.16.2",
 )

--- a/src/mkdocs_bibtex/__init__.py
+++ b/src/mkdocs_bibtex/__init__.py
@@ -1,6 +1,10 @@
+# Python imports
 import sys
+
+# 3rd party imports
 from mkdocs_bibtex.plugin import BibTexPlugin
 
+# Handle module versioning
 if sys.version_info[:2] >= (3, 8):
     from importlib import metadata
 else:

--- a/src/mkdocs_bibtex/config.py
+++ b/src/mkdocs_bibtex/config.py
@@ -1,0 +1,43 @@
+# 3rd party imports
+from mkdocs.config import base, config_options as c
+
+# Local imports
+from mkdocs_bibtex.type import CiteFormat, BibType
+
+
+class BibTexConfig(base.Config):
+    """Configuration of the BibTex pluging for mkdocs.
+
+    Options:
+        bib_file (string): Path or url to a single bibtex file for entries,
+            url example: https://api.zotero.org/*/items?format=bibtex
+        bib_dir (string): Path to a directory of bibtex files for entries.
+        csl_file (string, optional): Path or url to a CSL file, relative to mkdocs.yml.
+        cite_format (string, optional): Format of the citations in text. Should
+            one of "footnote", "inline", or "link". It defaults to "footnote".
+        bib_type (string, optional): Type of bibliography used in the document.
+            Should be either "global" or "per_page". It defaults to "per_page"
+        automatic_per_page (bool, optional): Automatically insert the bibliography
+            command at the end of each page. It defaults to True.
+        per_page_bib_command (string, optional): Command used to insert a per
+            page bibliography. It defaults to "\\bibliography".
+        global_bib_command (string, optional): Command to place a global
+            bibliography of all used references. It defaults to "\\full_bibliography"
+        ref_format (string, optional): Formatting string for the citation links.
+    """
+
+    # Input files
+    bib_file = c.Optional(c.Type(str))
+    bib_dir = c.Optional(c.Dir(exists=True))
+    csl_file = c.Optional(c.Type(str))
+
+    # General settings
+    cite_format = c.Choice(CiteFormat, default=CiteFormat.LINK)
+    bib_type = c.Choice(BibType, default=BibType.GLOBAL)
+    automatic_per_page = c.Type(bool, default=True)
+    ref_format = c.Type(str, default="{number}-{key}")
+    global_bib_ref = c.Type(str, default="/bibliography.md")
+
+    # Commands
+    per_page_bib_command = c.Type(str, default="\\bibliography")
+    global_bib_command = c.Type(str, default="\\full_bibliography")

--- a/src/mkdocs_bibtex/config.py
+++ b/src/mkdocs_bibtex/config.py
@@ -19,11 +19,13 @@ class BibTexConfig(base.Config):
             Should be either "global" or "per_page". It defaults to "per_page"
         automatic_per_page (bool, optional): Automatically insert the bibliography
             command at the end of each page. It defaults to True.
+        ref_format (string, optional): Formatting string for the citation links.
+        global_bib_ref (string, optional): Absolute to the file where the global
+            bibliography is rendered.
         per_page_bib_command (string, optional): Command used to insert a per
             page bibliography. It defaults to "\\bibliography".
         global_bib_command (string, optional): Command to place a global
             bibliography of all used references. It defaults to "\\full_bibliography"
-        ref_format (string, optional): Formatting string for the citation links.
     """
 
     # Input files
@@ -32,8 +34,13 @@ class BibTexConfig(base.Config):
     csl_file = c.Optional(c.Type(str))
 
     # General settings
-    cite_format = c.Choice(CiteFormat, default=CiteFormat.LINK)
-    bib_type = c.Choice(BibType, default=BibType.GLOBAL)
+    cite_format = c.Choice(
+        (CiteFormat.LINK.value, CiteFormat.FOOTNOTE.value, CiteFormat.INLINE.value),
+        default=CiteFormat.LINK.value,
+    )
+    bib_type = c.Choice(
+        (BibType.GLOBAL.value, BibType.PER_PAGE.value), default=BibType.GLOBAL.value
+    )
     automatic_per_page = c.Type(bool, default=True)
     ref_format = c.Type(str, default="{number}-{key}")
     global_bib_ref = c.Type(str, default="/bibliography.md")

--- a/src/mkdocs_bibtex/plugin.py
+++ b/src/mkdocs_bibtex/plugin.py
@@ -1,124 +1,123 @@
+# Python imports
 import re
 import time
 import validators
-from collections import OrderedDict
 from pathlib import Path
+from typing import Optional, Tuple
 
-from mkdocs.config import config_options
+# 3rd party imports
 from mkdocs.plugins import BasePlugin
+from mkdocs.exceptions import ConfigurationError
 from pybtex.database import BibliographyData, parse_file
 
-from mkdocs_bibtex.utils import (
-    find_cite_blocks,
-    extract_cite_keys,
-    format_bibliography,
-    format_pandoc,
-    format_simple,
-    insert_citation_keys,
-    tempfile_from_url,
-    log,
-)
+# Local imports
+from mkdocs_bibtex import utils
+from mkdocs_bibtex.config import BibTexConfig
+from mkdocs_bibtex.type import *
 
 
-class BibTexPlugin(BasePlugin):
-    """
-    Allows the use of bibtex in markdown content for MKDocs.
-
-    Options:
-        bib_file (string): path or url to a single bibtex file for entries,
-                           url example: https://api.zotero.org/*/items?format=bibtex
-        bib_dir (string): path to a directory of bibtex files for entries
-        bib_command (string): command to place a bibliography relevant to just that file
-                              defaults to \bibliography
-        bib_by_default (bool): automatically appends bib_command to markdown pages
-                               by default, defaults to true
-        full_bib_command (string): command to place a full bibliography of all references
-        csl_file (string, optional): path or url to a CSL file, relative to mkdocs.yml.
-        cite_inline (bool): Whether or not to render inline citations, requires CSL, defaults to false
-    """
-
-    config_scheme = [
-        ("bib_file", config_options.Type(str, required=False)),
-        ("bib_dir", config_options.Dir(exists=True, required=False)),
-        ("bib_command", config_options.Type(str, default="\\bibliography")),
-        ("bib_by_default", config_options.Type(bool, default=True)),
-        ("full_bib_command", config_options.Type(str, default="\\full_bibliography")),
-        ("csl_file", config_options.Type(str, default="")),
-        ("cite_inline", config_options.Type(bool, default=False)),
-        ("footnote_format", config_options.Type(str, default="{number}")),
-    ]
+class BibTexPlugin(BasePlugin[BibTexConfig]):
+    """BibTex plugin that makes bibtex available in mkdocs."""
 
     def __init__(self):
+        # Path to a CSL file
+        self.csl_file: Optional[str] = None
+        # Time at which the bibliography files were last parsed
+        self.last_configured: Optional[float] = None
+        # Index of citations of the whole website
+        self.global_citation_index: CitationIndex = {}
+        # Mapping from cite groups to a list of cite keys contained within
+        self.global_mapping: CitationBlockMapping = {}
+        # Available bibliography entries
         self.bib_data = None
-        self.all_references = OrderedDict()
-        self.unescape_for_arithmatex = False
-        self.configured = False
+        self.bib_data_bibtex = None
 
-    def on_startup(self, *, command, dirty):
-        """ Having on_startup() tells mkdocs to keep the plugin object upon rebuilds"""
+    def on_startup(self, *, command, dirty: bool):
+        """Having on_startup() tells mkdocs to keep the plugin object upon rebuilds"""
         pass
 
     def on_config(self, config):
-        """
-        Loads bibliography on load of config
-        """
+        """Loads bibliography on load of config"""
+        # List of file paths containing bibliography entries
+        bibfiles: list[str] = []
 
-        bibfiles = []
-
-        # Set bib_file from either url or path
+        # Set bib files from either URL or path
         if self.config.get("bib_file", None) is not None:
+            # If bib_file is a valid URL, cache it with tempfile
             is_url = validators.url(self.config["bib_file"])
-            # if bib_file is a valid URL, cache it with tempfile
             if is_url:
-                bibfiles.append(tempfile_from_url("bib file", self.config["bib_file"], ".bib"))
+                bibfiles.append(
+                    utils.tempfile_from_url("bib file", self.config["bib_file"], ".bib")
+                )
+            # If it is not an URL, treat is as a local path
             else:
                 bibfiles.append(self.config["bib_file"])
+
+        # Set bib files from directory
         elif self.config.get("bib_dir", None) is not None:
             bibfiles.extend(Path(self.config["bib_dir"]).rglob("*.bib"))
         else:  # pragma: no cover
-            raise Exception("Must supply a bibtex file or directory for bibtex files")
-
-        # load bibliography data
-        refs = {}
-        log.info(f"Loading data from bib files: {bibfiles}")
-        for bibfile in bibfiles:
-            log.debug(f"Parsing bibtex file {bibfile}")
-            bibdata = parse_file(bibfile)
-            refs.update(bibdata.entries)
-
-        if hasattr(self,"last_configured"):
-            # Skip rebuilding bib data if all files are older than the initial config
-            if all(Path(bibfile).stat().st_mtime < self.last_configured for bibfile in bibfiles):
-                log.info("BibTexPlugin: No changes in bibfiles.")
-                return config
-
-        # Clear references on reconfig
-        self.all_references = OrderedDict()
-
-        self.bib_data = BibliographyData(entries=refs)
-        self.bib_data_bibtex = self.bib_data.to_string("bibtex")
+            raise ConfigurationError("Must supply a bibtex file or directory for bibtex files")
 
         # Set CSL from either url or path (or empty)
         is_url = validators.url(self.config["csl_file"])
         if is_url:
-            self.csl_file = tempfile_from_url("CSL file", self.config["csl_file"], ".csl")
+            self.csl_file = utils.tempfile_from_url("CSL file", self.config["csl_file"], ".csl")
         else:
-            self.csl_file = self.config.get("csl_file", None)
+            self.csl_file = self.config["csl_file"]
 
         # Toggle whether or not to render citations inline (Requires CSL)
-        self.cite_inline = self.config.get("cite_inline", False)
-        if self.cite_inline and not self.csl_file:  # pragma: no cover
-            raise Exception("Must supply a CSL file in order to use cite_inline")
+        if self.config.cite_format == CiteFormat.INLINE and not self.csl_file:  # pragma: no cover
+            raise ConfigurationError("Must supply a CSL file in order to use cite_inline")
 
-        if "{number}" not in self.config.get("footnote_format"):
-            raise Exception("Must include `{number}` placeholder in footnote_format")
+        # Handle footnote format
+        if "{number}" not in self.config.ref_format and "{key}" not in self.config.ref_format:
+            raise ConfigurationError(
+                "Must include `{number}` or `{key}` placeholders in ref_format"
+            )
 
-        self.footnote_format = self.config.get("footnote_format")
-
-        self.last_configured = time.time()
+        # Skip rebuilding bib data if all files are older than the initial config
+        if self.last_configured is not None and all(
+            Path(bibfile).stat().st_mtime < self.last_configured for bibfile in bibfiles
+        ):
+            utils.log.info("[bibtex] No changes in bibfiles.")
+        else:
+            # Load bibliography data
+            utils.log.info(f"[bibtex] Loading data from bib files: {bibfiles}")
+            self.refresh_bib_data(bibfiles)
+            self.last_configured = time.time()
         return config
 
-    def on_page_markdown(self, markdown, page, config, files):
+    def refresh_bib_data(self, bibfiles: list[str]):
+        refs = {}
+        for bibfile in bibfiles:
+            utils.log.debug(f"[bibtex] Parsing bibtex file {bibfile}")
+            bibdata = parse_file(bibfile)
+            refs.update(bibdata.entries)
+
+        # Rebuild bibliography data
+        self.bib_data = BibliographyData(entries=refs)
+        self.bib_data_bibtex = self.bib_data.to_string("bibtex")
+
+    def on_files(self, files, config):
+        """Build global index if configured for global bibliography."""
+        # Build the index once for a global bibliography with unique numbering
+        if self.config.bib_type == BibType.GLOBAL:
+            utils.log.info("[bibtex] Building global bibliography index")
+
+            # Extract all cite keys from all pages
+            cite_keys: list[str] = []
+            for file in files:
+                if file.is_documentation_page():
+                    cite_keys.extend(utils.find_cite_blocks(file.content_string))
+
+            # Generating the index
+            self.global_citation_index, self.global_mapping = self.generate_index(cite_keys)
+        else:
+            utils.log.info("[bibtex] Global bibliography index not generated")
+        return files
+
+    def on_page_markdown(self, markdown, page, config, files) -> str:
         """
         Parses the markdown for each page, extracting the bibtex references
         If a local reference list is requested, this will render that list where requested
@@ -133,126 +132,116 @@ class BibTexPlugin(BasePlugin):
         4. Insert the bibliography into the markdown
         5. Insert the full bibliograph into the markdown
         """
+        # If configured for a local bibliography, configured a local index
+        if self.config.bib_type == BibType.PER_PAGE:
+            utils.log.debug("[bibtex] Generating local bibliography index for page: %s", page.title)
+            cite_keys = utils.find_cite_blocks(markdown)
+            citation_index, mapping = self.generate_index(cite_keys)
+        else:
+            citation_index = self.global_citation_index
+            mapping = self.global_mapping
 
-        # 1. Grab all the cited keys in the markdown
-        cite_keys = find_cite_blocks(markdown)
-
-        # 2. Convert all the citations to text references
-        citation_quads = self.format_citations(cite_keys)
-
-        # 3. Convert cited keys to citation,
-        # or a footnote reference if inline_cite is false.
-        if self.cite_inline:
-            markdown = insert_citation_keys(
-                citation_quads,
+        # Convert cited keys to citation
+        utils.log.debug("[bibtex] Replacing citation keys with the generated ones")
+        if self.config.cite_format == CiteFormat.INLINE:
+            markdown = utils.insert_citation_keys_inline(
+                citation_index,
                 markdown,
                 self.csl_file,
                 self.bib_data_bibtex,
             )
-        else:
-            markdown = insert_citation_keys(citation_quads, markdown)
+        elif self.config.cite_format == CiteFormat.FOOTNOTE:
+            markdown = utils.insert_citation_keys_footnote(citation_index, mapping, markdown)
+        elif self.config.cite_format == CiteFormat.LINK:
+            markdown = utils.insert_citation_keys_link(citation_index, mapping, markdown)
 
-        # 4. Insert in the bibliopgrahy text into the markdown
-        bib_command = self.config.get("bib_command", "\\bibliography")
+        # Automatically insert the per page bibliography if configured
+        if self.config.automatic_per_page:
+            markdown += f"\n{self.config.per_page_bib_command}"
 
-        if self.config.get("bib_by_default"):
-            markdown += f"\n{bib_command}"
+        # Insert a local bibliography per page and remove global tags
+        if self.config.bib_type == BibType.PER_PAGE:
+            add_line = self.config.cite_format == CiteFormat.LINK
+            markdown = re.sub(
+                re.escape(self.config.per_page_bib_command),
+                self.generate_bibliography(citation_index, add_line),
+                markdown,
+            )
+            markdown = re.sub(re.escape(self.config.global_bib_command), "", markdown)
 
-        bibliography = format_bibliography(citation_quads)
-        markdown = re.sub(
-            re.escape(bib_command),
-            bibliography,
-            markdown,
-        )
-
-        # 5. Build the full Bibliography and insert into the text
-        full_bib_command = self.config.get("full_bib_command", "\\full_bibliography")
-
-        markdown = re.sub(
-            re.escape(full_bib_command),
-            self.full_bibliography,
-            markdown,
-        )
-
+        # Insert a global bibliography and remove the local tags
+        elif self.config.bib_type == BibType.GLOBAL:
+            markdown = re.sub(
+                re.escape(self.config.global_bib_command),
+                self.generate_bibliography(citation_index),
+                markdown,
+            )
+            markdown = re.sub(re.escape(self.config.per_page_bib_command), "", markdown)
         return markdown
 
-    def format_footnote_key(self, number):
-        """
-        Create footnote key based on footnote_format
+    def generate_index(self, cite_keys: list[str]) -> Tuple[CitationIndex, CitationBlockMapping]:
+        """Formats a list of citations into a citation index
 
         Args:
-            number (int): citation number
+            cite_keys: List of full cite keys that may be compound keys
 
         Returns:
-            formatted footnote
+            Citation index containing all unique citations and the metadata
+            needed to render the corresponding key and the bibliography.
         """
-        return self.footnote_format.format(number=number)
+        # Go through all citations in the cite keys and split compound citations
+        index: CitationIndex = {}
+        mapping: CitationBlockMapping = {}
+        idx = 1
+        for cite_block in cite_keys:
+            mapping[cite_block] = []
+            for key in utils.extract_cite_keys(cite_block):
 
-    def format_citations(self, cite_keys):
-        """
-        Formats references into citation quads and adds them to the global registry
+                # Check if the key in the bibliography
+                if key not in self.bib_data.entries:
+                    utils.log.warning("[bibtex] %s not found in bibliography entries", key)
+                    continue
 
-        Args:
-            cite_keys (list): List of full cite_keys that maybe compound keys
+                # If we don't have the key in the index, create a new entry
+                if key not in index:
 
-        Returns:
-            citation_quads: quad tuples of the citation inforamtion
-        """
+                    # Format the key for markdown
+                    entry = self.bib_data.entries[key]
+                    if self.config.csl_file is not None:
+                        formatted_md = utils.format_pandoc(entry, self.csl_file)
+                    else:
+                        formatted_md = utils.format_simple(entry)
 
-        # Deal with arithmatex fix at some point
+                    # Generate a link to the reference
+                    ref = self.config.ref_format
+                    ref = re.sub(re.escape("{number}"), str(idx), ref)
+                    ref = re.sub(re.escape("{key}"), key, ref)
+                    page = (
+                        self.config.global_bib_ref if self.config.bib_type == BibType.GLOBAL else ""
+                    )
 
-        # 1. Extract the keys from the keyset
-        entries = OrderedDict()
-        pairs = [
-            [cite_block, key]
-            for cite_block in cite_keys
-            for key in extract_cite_keys(cite_block)
-        ]
-        keys = list(OrderedDict.fromkeys([k for _, k in pairs]).keys())
-        numbers = {k: str(n + 1) for n, k in enumerate(keys)}
+                    # Create the index entry
+                    index[key] = CitationIndexEntry(
+                        idx=idx,
+                        formatted_html=utils.format_simple(entry, html_backend=True),
+                        formatted_md=formatted_md,
+                        ref=ref,
+                        page=page,
+                    )
+                    idx += 1
 
-        # Remove non-existant keys from pairs
-        pairs = [p for p in pairs if p[1] in self.bib_data.entries]
+                mapping[cite_block].append(key)
 
-        # 2. Collect any unformatted reference keys
-        for _, key in pairs:
-            if key not in self.all_references:
-                entries[key] = self.bib_data.entries[key]
+        return (index, mapping)
 
-        # 3. Format entries
-        log.debug("Formatting all bib entries...")
-        if self.csl_file:
-            self.all_references.update(format_pandoc(entries, self.csl_file))
-        else:
-            self.all_references.update(format_simple(entries))
-        log.debug("SUCCESS Formatting all bib entries")
+    def generate_bibliography(self, index: CitationIndex, add_line=False) -> str:
+        # Generate bibliography depending on the selected citation type
+        if self.config.cite_format in [CiteFormat.FOOTNOTE, CiteFormat.INLINE]:
+            bibliography = utils.format_bibliography_footnote(index)
+        elif self.config.cite_format == CiteFormat.LINK:
+            bibliography = utils.format_bibliography_link(index)
 
-        # 4. Construct quads
-        quads = [
-            (
-                cite_block,
-                key,
-                self.format_footnote_key(numbers[key]),
-                self.all_references[key],
-            )
-            for cite_block, key in pairs
-        ]
-
-        # List the quads in order to remove duplicate entries
-        return list(dict.fromkeys(quads))
-
-    @property
-    def full_bibliography(self):
-        """
-        Returns the full bibliography text
-        """
-
-        bibliography = []
-        for number, (key, citation) in enumerate(self.all_references.items()):
-            bibliography_text = "[^{}]: {}".format(
-                number,
-                citation,
-            )
-            bibliography.append(bibliography_text)
-
-        return "\n".join(bibliography)
+        # Add a separator line in front of the bibliography if requested
+        if add_line and len(index) != 0:
+            bibliography = "\n---\n" + bibliography
+        return bibliography

--- a/src/mkdocs_bibtex/type.py
+++ b/src/mkdocs_bibtex/type.py
@@ -1,7 +1,6 @@
 # Python imports
 from enum import Enum
 from dataclasses import dataclass
-from typing import Optional
 
 
 class CiteFormat(Enum):

--- a/src/mkdocs_bibtex/type.py
+++ b/src/mkdocs_bibtex/type.py
@@ -1,0 +1,29 @@
+# Python imports
+from enum import Enum
+from dataclasses import dataclass
+from typing import Optional
+
+
+class CiteFormat(Enum):
+    FOOTNOTE = "footnote"
+    INLINE = "inline"
+    LINK = "link"
+
+
+class BibType(Enum):
+    GLOBAL = "global"
+    PER_PAGE = "per_page"
+
+
+@dataclass
+class CitationIndexEntry:
+    idx: int
+    formatted_html: str
+    formatted_md: str
+    ref: str
+    page: str
+
+
+CitationIndex = dict[str, CitationIndexEntry]
+
+CitationBlockMapping = dict[str, list[str]]

--- a/src/mkdocs_bibtex/utils.py
+++ b/src/mkdocs_bibtex/utils.py
@@ -1,87 +1,90 @@
+# Python imports
 import logging
 import re
 import requests
 import tempfile
-from collections import OrderedDict
 from functools import lru_cache
-from itertools import groupby
 from pathlib import Path
 from packaging.version import Version
 
+# 3rd party imports
 import mkdocs
 import pypandoc
 
 from pybtex.backends.markdown import Backend as MarkdownBackend
-from pybtex.database import BibliographyData
+from pybtex.backends.html import Backend as HtmlBackend
+from pybtex.database import BibliographyData, Entry
 from pybtex.style.formatting.plain import Style as PlainStyle
+
+# Local imports
+from mkdocs_bibtex.type import *
 
 # Grab a logger
 log = logging.getLogger("mkdocs.plugins.mkdocs-bibtex")
 
 # Add the warning filter only if the version is lower than 1.2
 # Filter doesn't do anything since that version
-MKDOCS_LOG_VERSION = '1.2'
+MKDOCS_LOG_VERSION = "1.2"
 if Version(mkdocs.__version__) < Version(MKDOCS_LOG_VERSION):
     from mkdocs.utils import warning_filter
+
     log.addFilter(warning_filter)
 
 
-def format_simple(entries):
-    """
-    Format the entries using a simple built in style
+def format_simple(entry: Entry, html_backend: bool = False) -> str:
+    """Format the entry using a simple builtin style.
 
     Args:
-        entries (dict): dictionary of entries
+        entry (Entry): Bibliography entry.
+        html_backend (bool): Format the entry as HTML if set to True.
+            Format the entry as markdown otherwise.
 
     Returns:
-        references (dict): dictionary of citation texts
+        Citation formatted as markdown or HTML.
     """
+    # Select style and backend
     style = PlainStyle()
-    backend = MarkdownBackend()
-    citations = OrderedDict()
-    for key, entry in entries.items():
-        log.debug(f"Converting bibtex entry {key!r} without pandoc")
-        formatted_entry = style.format_entry("", entry)
-        entry_text = formatted_entry.text.render(backend)
-        entry_text = entry_text.replace("\n", " ")
-        # Local reference list for this file
-        citations[key] = (
-            entry_text.replace("\\(", "(").replace("\\)", ")").replace("\\.", ".")
-        )
-        log.debug(f"SUCCESS Converting bibtex entry {key!r} without pandoc")
-    return citations
+    backend = HtmlBackend() if html_backend else MarkdownBackend()
+
+    # Apply style to the entry
+    formatted_entry = style.format_entry("", entry)
+    entry_text = formatted_entry.text.render(backend)
+
+    # Modify the entry before returning it
+    return entry_text.replace("\n", " ").replace("\\(", "(").replace("\\)", ")").replace("\\.", ".")
 
 
-def format_pandoc(entries, csl_path):
-    """
-    Format the entries using pandoc
+def format_pandoc(entry: Entry, csl_path: str) -> str:
+    """Format the entry using pandoc.
 
     Args:
-        entries (dict): dictionary of entries
-        csl_path (str): path to formatting CSL Fle
+        entry (Entry): Bibliography entry.
+        csl_path (str): Path to formatting CSL File.
     Returns:
-        references (dict): dictionary of citation texts
+        Citation formatted as markdown.
     """
+    # Grab the pandoc version
     pandoc_version = tuple(int(ver) for ver in pypandoc.get_pandoc_version().split("."))
-    citations = OrderedDict()
     is_new_pandoc = pandoc_version >= (2, 11)
-    msg = "pandoc>=2.11" if is_new_pandoc else "pandoc<2.11"
-    for key, entry in entries.items():
-        bibtex_string = BibliographyData(entries={entry.key: entry}).to_string("bibtex")
-        log.debug(f"--Converting bibtex entry {key!r} with CSL file {csl_path!r} using {msg}")
-        if is_new_pandoc:
-            citations[key] = _convert_pandoc_new(bibtex_string, csl_path)
-        else:
-            citations[key] = _convert_pandoc_legacy(bibtex_string, csl_path)
-        log.debug(f"--SUCCESS Converting bibtex entry {key!r} with CSL file {csl_path!r} using {msg}")
 
-    return citations
+    # Apply styling
+    bibtex_string = BibliographyData(entries={entry.key: entry}).to_string("bibtex")
+    if is_new_pandoc:
+        entry_text = _convert_pandoc_new(bibtex_string, csl_path)
+    else:
+        entry_text = _convert_pandoc_legacy(bibtex_string, csl_path)
+    return entry_text
 
 
-def _convert_pandoc_new(bibtex_string, csl_path):
-    """
-    Converts the PyBtex entry into formatted markdown citation text
-    using pandoc version 2.11 or newer
+def _convert_pandoc_new(bibtex_string: str, csl_path: str) -> str:
+    """Converts the PyBtex entry into formatted markdown citation text
+    using pandoc version 2.11 or newer.
+
+    Args:
+        bibtex_string (str): Bibliography entry formatted as bibtex string.
+        csl_path (str): Path to formatting CSL File.
+    Returns:
+        Citation formatted as markdown.
     """
     markdown = pypandoc.convert_text(
         source=bibtex_string,
@@ -94,10 +97,9 @@ def _convert_pandoc_new(bibtex_string, csl_path):
         ],
     )
 
-    markdown = " ".join(markdown.split("\n"))
     # Remove newlines from any generated span tag (non-capitalized words)
+    markdown = " ".join(markdown.split("\n"))
     markdown = re.compile(r"<\/span>[\r\n]").sub("</span> ", markdown)
-
     citation_regex = re.compile(
         r"<span\s+class=\"csl-(?:left-margin|right-inline)\">(.+?)(?=<\/span>)<\/span>"
     )
@@ -108,43 +110,15 @@ def _convert_pandoc_new(bibtex_string, csl_path):
     return citation.strip()
 
 
-@lru_cache(maxsize=1024)
-def _convert_pandoc_citekey(bibtex_string, csl_path, fullcite):
-    """
-    Uses pandoc to convert a markdown citation key reference
-    to a rendered markdown citation in the given CSL format.
+def _convert_pandoc_legacy(bibtex_string: str, csl_path: str) -> str:
+    """Converts the PyBtex entry into formatted markdown citation text
+    using pandoc version older than 2.11.
 
-        Limitation (atleast for harvard.csl): multiple citekeys
-        REQUIRE a '; ' separator to render correctly:
-            - [see @test; @test2] Works
-            - [see @test and @test2] Doesn't work
-    """
-    with tempfile.TemporaryDirectory() as tmpdir:
-        bib_path = Path(tmpdir).joinpath("temp.bib")
-        with open(bib_path, "wt", encoding="utf-8") as bibfile:
-            bibfile.write(bibtex_string)
-
-        log.debug(f"----Converting pandoc citation key {fullcite!r} with CSL file {csl_path!r} and Bibliography file"
-                  f" '{bib_path!s}'...")
-        markdown = pypandoc.convert_text(
-            source=fullcite,
-            to="markdown-citations",
-            format="markdown",
-            extra_args=["--citeproc", "--csl", csl_path, "--bibliography", bib_path],
-        )
-        log.debug(f"----SUCCESS Converting pandoc citation key {fullcite!r} with CSL file {csl_path!r} and "
-                  f"Bibliography file '{bib_path!s}'")
-
-    # Return only the citation text (first line(s))
-    # remove any extra linebreaks to accommodate large author names
-    markdown = re.compile(r"[\r\n]").sub("", markdown)
-    return markdown.split(":::")[0].strip()
-
-
-def _convert_pandoc_legacy(bibtex_string, csl_path):
-    """
-    Converts the PyBtex entry into formatted markdown citation text
-    using pandoc version older than 2.11
+    Args:
+        bibtex_string (str): Bibliography entry formatted as bibtex string.
+        csl_path (str): Path to formatting CSL File.
+    Returns:
+        Citation formatted as markdown.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
         bib_path = Path(tmpdir).joinpath("temp.bib")
@@ -169,25 +143,28 @@ nocite: '@*'
     return citation.strip()
 
 
-def extract_cite_keys(cite_block):
-    """
-    Extract just the keys from a citation block
+def extract_cite_keys(cite_block: str) -> list[str]:
+    """Extract just the keys from a cite block.
+
+    Args:
+        cite_block (str): Cite block extracted from an mkdocs page.
+
+    Returns:
+        List of cite keys contained in the cite block.
     """
     cite_regex = re.compile(r"@([\w\.:-]*)")
     cite_keys = re.findall(cite_regex, cite_block)
-
     return cite_keys
 
 
-def find_cite_blocks(markdown):
-    """
-    Finds entire cite blocks in the markdown text
+def find_cite_blocks(markdown: str) -> list[str]:
+    """Finds entire cite blocks in the markdown text.
 
     Args:
-        markdown (str): the markdown text to be extract citation
+        markdown (str): The markdown text to be extract citation
                         blocks from
 
-    regex explanation:
+    Regex explanation:
     - first group  (1): everything. (the only thing we need)
     - second group (2): (?:(?:\[(-{0,1}[^@]*)) |\[(?=-{0,1}@))
     - third group  (3): ((?:-{0,1}@\w*(?:; ){0,1})+)
@@ -207,88 +184,166 @@ def find_cite_blocks(markdown):
 
     Does NOT match: [mail@example.com]
     DOES match [mail @example.com] as [mail][@example][com]
+
+    Returns:
+        A list of citation blocks.
     """
+    # Generate the regex
     r = r"((?:(?:\[(-{0,1}[^@]*)) |\[(?=-{0,1}@))((?:-{0,1}@\w*(?:; ){0,1})+)(?:[^\]\n]{0,1} {0,1})([^\]\n]*)\])"
     cite_regex = re.compile(r)
 
-    citation_blocks = [
+    # Extract the citation blocks from the markdown
+    return [
         # We only care about the block (group 1)
         (matches.group(1))
         for matches in re.finditer(cite_regex, markdown)
     ]
 
-    return citation_blocks
 
-
-def insert_citation_keys(citation_quads, markdown, csl=False, bib=False):
-    """
-    Insert citations into the markdown text replacing
-    the old citation keys
+def insert_citation_keys_footnote(
+    citation_index: CitationIndex, mapping: CitationBlockMapping, markdown: str
+) -> str:
+    """Insert citations into the markdown text replacing the old citation keys.
+    This function inserts the citations as footnotes.
 
     Args:
-        citation_quads (tuple): a quad tuple of all citation info
-        markdown (str): the markdown text to modify
+        citation_index (CitationIndex): Citation index containing bibliography entries.
+        mapping (CitationBlockMapping): Mapping from cite blocks to the cite keys they contain.
+        markdown (str): Markdown text to modify.
 
     Returns:
-        markdown (str): the modified Markdown
+        Modified markdown.
     """
-
-    log.debug("Replacing citation keys with the generated ones...")
-
-    # Renumber quads if using numbers for citation links
-
-    grouped_quads = [list(g) for _, g in groupby(citation_quads, key=lambda x: x[0])]
-    for quad_group in grouped_quads:
-        full_citation = quad_group[0][0]  # the full citation block
-        replacement_citaton = "".join(["[^{}]".format(quad[2]) for quad in quad_group])
-
-        # if cite_inline is true, convert full_citation with pandoc and add to replacement_citaton
-        if csl and bib:
-            log.debug(f"--Rendering citation inline for {full_citation!r}...")
-            # Verify that the pandoc installation is newer than 2.11
-            pandoc_version = pypandoc.get_pandoc_version()
-            pandoc_version_tuple = tuple(int(ver) for ver in pandoc_version.split("."))
-            if pandoc_version_tuple <= (2, 11):
-                raise RuntimeError(
-                    f"Your version of pandoc (v{pandoc_version}) is "
-                    "incompatible with the cite_inline feature."
-                )
-
-            inline_citation = _convert_pandoc_citekey(bib, csl, full_citation)
-            replacement_citaton = f" {inline_citation}{replacement_citaton}"
-
-            # Make sure inline citations doesn't get an extra whitespace by
-            # replacing it with whitespace added first
-            markdown = markdown.replace(f" {full_citation}", replacement_citaton)
-            log.debug(f"--SUCCESS Rendering citation inline for {full_citation!r}")
-
-        markdown = markdown.replace(full_citation, replacement_citaton)
-
-    log.debug("SUCCESS Replacing citation keys with the generated ones")
-
+    # Generate the footnore with the correct format and inject in markdown
+    for cite_group, cite_keys in mapping.items():
+        replacement_citaton = "".join(
+            ["[^{}]".format(citation_index[cite_key].ref) for cite_key in cite_keys]
+        )
+        markdown = markdown.replace(cite_group, replacement_citaton)
     return markdown
 
 
-def format_bibliography(citation_quads):
-    """
-    Generates a bibliography from the citation quads
+def insert_citation_keys_link(
+    citation_index: CitationIndex, mapping: CitationBlockMapping, markdown: str
+) -> str:
+    """Insert citations into the markdown text replacing the old citation keys.
+    This function inserts the citations as a link to a bibliography.
 
     Args:
-        citation_quads (tuple): a quad tuple of all citation info
+        citation_index (CitationIndex): Citation index containing bibliography entries.
+        mapping (CitationBlockMapping): Mapping from cite blocks to the cite keys they contain.
+        markdown (str): Markdown text to modify.
 
     Returns:
-        markdown (str): the Markdown string for the bibliography
+        Modified markdown.
     """
-    new_bib = {quad[2]: quad[3] for quad in citation_quads}
-    bibliography = []
-    for key, citation in new_bib.items():
-        bibliography_text = "[^{}]: {}".format(key, citation)
-        bibliography.append(bibliography_text)
+    # Generate the link with the correct format and inject in markdown
+    for cite_group, cite_keys in mapping.items():
+        replacement_citaton = ", ".join(
+            [
+                "[{}]({}#{})".format(
+                    citation_index[cite_key].idx,
+                    citation_index[cite_key].page,
+                    citation_index[cite_key].ref,
+                )
+                for cite_key in cite_keys
+            ]
+        )
+        replacement_citaton = "[" + replacement_citaton + "]"
+        markdown = markdown.replace(cite_group, replacement_citaton)
+    return markdown
 
+
+def insert_citation_keys_inline(
+    citation_index: CitationIndex, mapping: CitationBlockMapping, markdown: str, csl_path: str, bib
+) -> str:
+    """Insert citations into the markdown text replacing the old citation keys.
+    This function inserts the citations as inline citations.
+
+    Args:
+        citation_index (CitationIndex): Citation index containing bibliography entries.
+        mapping (CitationBlockMapping): Mapping from cite blocks to the cite keys they contain.
+        markdown (str): Markdown text to modify.
+        csl_path (str): Path the CSL file used to format the citations.
+        bib
+
+    Returns:
+        Modified markdown.
+    """
+    # Generate the link with the correct format and inject in markdown
+    for cite_group, cite_keys in mapping.items():
+        replacement_citaton = "".join(
+            ["[^{}]".format(citation_index[cite_key].ref) for cite_key in cite_keys]
+        )
+
+        # Verify that the pandoc installation is newer than 2.11
+        pandoc_version = pypandoc.get_pandoc_version()
+        pandoc_version_tuple = tuple(int(ver) for ver in pandoc_version.split("."))
+        if pandoc_version_tuple <= (2, 11):
+            raise RuntimeError(
+                f"Your version of pandoc (v{pandoc_version}) is "
+                "incompatible with the cite_inline feature."
+            )
+
+        # Convert full_citation with pandoc and add to replacement_citaton
+        log.debug(f"--Rendering citation inline for {cite_group!r}...")
+        inline_citation = _convert_pandoc_citekey(bib, csl_path, cite_group)
+        replacement_citaton = f" {inline_citation}{replacement_citaton}"
+
+        # Make sure inline citations doesn't get an extra whitespace by
+        # replacing it with whitespace added first
+        markdown = markdown.replace(f" {cite_group}", replacement_citaton)
+        log.debug(f"--SUCCESS Rendering citation inline for {cite_group!r}")
+
+        # Replace full citations with footnotes
+        markdown = markdown.replace(cite_group, replacement_citaton)
+    return markdown
+
+
+def format_bibliography_footnote(citation_index: CitationIndex) -> str:
+    """Generates a footnote bibliography from the citation index.
+
+    Args:
+        citation_index (CitationIndex): Citation index containing bibliography entries.
+
+    Returns:
+        Markdown string for the bibliography.
+    """
+    bibliography = []
+    for _, value in citation_index.items():
+        bibliography_text = "[^{}]: {}".format(value.ref, value.formatted_md)
+        bibliography.append(bibliography_text)
     return "\n".join(bibliography)
 
 
-def tempfile_from_url(name, url, suffix):
+def format_bibliography_link(citation_index: CitationIndex) -> str:
+    """Generates a link bibliography from the citation index.
+
+    Args:
+        citation_index (CitationIndex): Citation index containing bibliography entries.
+
+    Returns:
+        Markdown string for the bibliography.
+    """
+    # Generate a list of HTML table strings containing the rows of the bibliography
+    bibliography = []
+    for _, value in citation_index.items():
+        table_cell_ref = '<td style="border:none; padding: 0.5vw;">[{}]</td>'.format(value.idx)
+        table_cell_bib = '<td style="border:none; padding: 0.5vw;">{}</td>'.format(
+            value.formatted_html
+        )
+        table_row = '<tr style="all: unset;" id="{}"> {} {} </tr>'.format(
+            value.ref, table_cell_ref, table_cell_bib
+        )
+        bibliography.append(table_row)
+
+    # Merge the rows into a full HTML table
+    output = "\n".join(bibliography)
+    output = '<table style="all: unset; border-collapse:collapse;">' + output + "</table>"
+    return output
+
+
+def tempfile_from_url(name, url, suffix) -> str:
     log.debug(f"Downloading {name} from URL {url} to temporary file...")
     for i in range(3):
         try:
@@ -298,7 +353,9 @@ def tempfile_from_url(name, url, suffix):
                     f"Couldn't download the url: {url}.\n Status Code: {dl.status_code}"
                 )
 
-            file = tempfile.NamedTemporaryFile(mode="wt", encoding="utf-8", suffix=suffix, delete=False)
+            file = tempfile.NamedTemporaryFile(
+                mode="wt", encoding="utf-8", suffix=suffix, delete=False
+            )
             file.write(dl.text)
             file.close()
             log.info(f"{name} downladed from URL {url} to temporary file ({file})")
@@ -306,6 +363,47 @@ def tempfile_from_url(name, url, suffix):
 
         except requests.exceptions.RequestException:  # pragma: no cover
             pass
-    raise RuntimeError(
-        f"Couldn't successfully download the url: {url}"
-    )  # pragma: no cover
+    raise RuntimeError(f"Couldn't successfully download the url: {url}")  # pragma: no cover
+
+
+@lru_cache(maxsize=1024)
+def _convert_pandoc_citekey(bibtex_string: str, csl_path: str, fullcite: str) -> str:
+    """Uses pandoc to convert a markdown citation key reference
+    to a rendered markdown citation in the given CSL format.
+
+        Limitation (atleast for harvard.csl): multiple citekeys
+        REQUIRE a '; ' separator to render correctly:
+            - [see @test; @test2] Works
+            - [see @test and @test2] Doesn't work
+
+    Args:
+        bibtex_string (str): Bibliography entry formatted as bibtex string.
+        csl_path (str): Path to formatting CSL File.
+        fullcite (str): Cite group string.
+    Returns:
+        Citation formatted as markdown.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        bib_path = Path(tmpdir).joinpath("temp.bib")
+        with open(bib_path, "wt", encoding="utf-8") as bibfile:
+            bibfile.write(bibtex_string)
+
+        log.debug(
+            f"----Converting pandoc citation key {fullcite!r} with CSL file {csl_path!r} and Bibliography file"
+            f" '{bib_path!s}'..."
+        )
+        markdown = pypandoc.convert_text(
+            source=fullcite,
+            to="markdown-citations",
+            format="markdown",
+            extra_args=["--citeproc", "--csl", csl_path, "--bibliography", bib_path],
+        )
+        log.debug(
+            f"----SUCCESS Converting pandoc citation key {fullcite!r} with CSL file {csl_path!r} and "
+            f"Bibliography file '{bib_path!s}'"
+        )
+
+    # Return only the citation text (first line(s))
+    # remove any extra linebreaks to accommodate large author names
+    markdown = re.compile(r"[\r\n]").sub("", markdown)
+    return markdown.split(":::")[0].strip()

--- a/src/mkdocs_bibtex/utils.py
+++ b/src/mkdocs_bibtex/utils.py
@@ -6,17 +6,24 @@ from collections import OrderedDict
 from functools import lru_cache
 from itertools import groupby
 from pathlib import Path
+from packaging.version import Version
 
+import mkdocs
 import pypandoc
-from mkdocs.utils import warning_filter
 
 from pybtex.backends.markdown import Backend as MarkdownBackend
 from pybtex.database import BibliographyData
 from pybtex.style.formatting.plain import Style as PlainStyle
 
-
+# Grab a logger
 log = logging.getLogger("mkdocs.plugins.mkdocs-bibtex")
-log.addFilter(warning_filter)
+
+# Add the warning filter only if the version is lower than 1.2
+# Filter doesn't do anything since that version
+MKDOCS_LOG_VERSION = '1.2'
+if Version(mkdocs.__version__) < Version(MKDOCS_LOG_VERSION):
+    from mkdocs.utils import warning_filter
+    log.addFilter(warning_filter)
 
 
 def format_simple(entries):

--- a/test_files/test_features.py
+++ b/test_files/test_features.py
@@ -3,6 +3,7 @@ This test file checks to make sure each feature works rather than checking each
 function. Each feature should have a single test function that covers all the python
 functions it that would need to be tested
 """
+
 import os
 
 import pytest
@@ -35,7 +36,6 @@ def plugin():
     return plugin
 
 
-
 @pytest.fixture
 def plugin_advanced_pandoc(plugin):
     """
@@ -48,12 +48,10 @@ def plugin_advanced_pandoc(plugin):
         pytest.skip(f"Unsupported version of pandoc (v{pandoc_version}) installed.")
 
     plugin.config["bib_file"] = os.path.join(test_files_dir, "test.bib")
-    plugin.config["csl_file"] = os.path.join(
-        test_files_dir, "springer-basic-author-date.csl"
-    )
+    plugin.config["csl_file"] = os.path.join(test_files_dir, "springer-basic-author-date.csl")
     plugin.config["cite_inline"] = True
 
-    delattr(plugin,"last_configured")
+    delattr(plugin, "last_configured")
     plugin.on_config(plugin.config)
 
     return plugin
@@ -163,8 +161,7 @@ def test_compound_citations(plugin):
 
     assert "[^1]: First Author and Second Author" in bib
     assert (
-        "[^2]: First Author and Second Author. Test Title (TT). *Testing Journal (TJ)*, 2019"
-        in bib
+        "[^2]: First Author and Second Author. Test Title (TT). *Testing Journal (TJ)*, 2019" in bib
     )
 
     assert [

--- a/test_files/test_plugin.py
+++ b/test_files/test_plugin.py
@@ -64,7 +64,9 @@ def test_on_page_markdown(plugin):
     )
 
     # ensure there are two items in bibliography
-    test_markdown = "This is a citation. [@test2] This is another citation [@test]\n\n \\bibliography"
+    test_markdown = (
+        "This is a citation. [@test2] This is another citation [@test]\n\n \\bibliography"
+    )
 
     assert "[^2]:" in plugin.on_page_markdown(test_markdown, None, None, None)
 
@@ -78,17 +80,19 @@ def test_on_page_markdown(plugin):
     # ensure nonexistant citekeys are removed correctly (not replaced)
     test_markdown = "A non-existant citekey. [@i_do_not_exist]"
 
-    assert "[@i_do_not_exist]" in plugin.on_page_markdown(
-        test_markdown, None, None, None
-    )
+    assert "[@i_do_not_exist]" in plugin.on_page_markdown(test_markdown, None, None, None)
 
     # Ensure if an item is referenced multiple times, it only shows up as one reference
-    test_markdown = "This is a citation. [@test] This is another citation [@test]\n\n \\bibliography"
+    test_markdown = (
+        "This is a citation. [@test] This is another citation [@test]\n\n \\bibliography"
+    )
 
     assert "[^2]" not in plugin.on_page_markdown(test_markdown, None, None, None)
 
     # Ensure item only shows up once even if used in multiple places as both a compound and lone cite key
-    test_markdown = "This is a citation. [@test; @test2] This is another citation [@test]\n\n \\bibliography"
+    test_markdown = (
+        "This is a citation. [@test; @test2] This is another citation [@test]\n\n \\bibliography"
+    )
 
     assert "[^3]" not in plugin.on_page_markdown(test_markdown, None, None, None)
 

--- a/test_files/test_utils.py
+++ b/test_files/test_utils.py
@@ -43,8 +43,7 @@ def test_format_simple(entries):
     assert all(entry != citations[k] for k, entry in entries.items())
 
     assert (
-        citations["test"]
-        == "First Author and Second Author. Test title. *Testing Journal*, 2019."
+        citations["test"] == "First Author and Second Author. Test title. *Testing Journal*, 2019."
     )
     assert (
         citations["test2"]
@@ -59,8 +58,7 @@ def test_format_pandoc(entries):
     assert all(entry != citations[k] for k, entry in entries.items())
 
     assert (
-        citations["test"]
-        == "Author, F. & Author, S. Test title. *Testing Journal* **1**, (2019)."
+        citations["test"] == "Author, F. & Author, S. Test title. *Testing Journal* **1**, (2019)."
     )
     assert (
         citations["test2"]


### PR DESCRIPTION
Hello @shyamd!

One feature that would be very useful for my work would be a global and latex-like bibliography. While thinking about this feature, I noted the following:

- The content of the global bibliography should be independent of where the `\full_bibliography` tag is located in the documentation.
- Footnotes are well suited for local bibliography, but not for a global one as they can't really refer to another page.
- The indices used to refer to a bibliography entry should be unique across the whole documentation for a global bibliography

I gave this project a try and ended up doing a pretty extensive rewrite of the plugin ...
I tried to fix the first issue by pre-parsing the files of the documentation in the `on_file` mkdocs callback.
The second issue is handled by introducing different citation formats (`footnote`, `inline`, `link`).
The last issue is fixed by having global or per-page bibliography indexes depending on the setting chosen by the user.

I have also changed some of the configuration options of the plugin.
The default behavior results in the same output as today:
```yml
plugins:
  - bibtex:
      bib_file: "refs.bib"
      cite_format: "footnote"
      bib_type: "per_page"
```

A global bibliography would be configured this way:
```yml
plugins:
  - bibtex:
      bib_file: "refs.bib"
      cite_format: "link"
      bib_type: "global"
      global_bib_ref: "\bibliography.md"
```

Even though there are quite a lot of changes that should still be made before this can be merged, it is in a mostly functional state. I was curious if you would be interested in taking over some of these changes in the official plugin. 

I have not yet updated any of the tests, documentation, etc.