### PR TITLE
FIX: Not invalidating citation blocks with 0 citations

### DIFF
--- a/src/mkdocs_bibtex/citation.py
+++ b/src/mkdocs_bibtex/citation.py
@@ -67,9 +67,9 @@ class CitationBlock:
         citation_blocks = []
         for match in CITATION_BLOCK_REGEX.finditer(markdown):
             try:
-                citation_blocks.append(
-                    CitationBlock(raw=match.group(1), citations=Citation.from_markdown(match.group(1)))
-                )
+                citations = Citation.from_markdown(match.group(1))
+                if len(citations) > 0:
+                    citation_blocks.append(CitationBlock(raw=match.group(1), citations=citations))
             except Exception as e:
                 print(f"Error extracting citations from block: {e}")
         return citation_blocks

--- a/test_files/test_citation.py
+++ b/test_files/test_citation.py
@@ -135,3 +135,10 @@ def test_citation_string():
     citations = [citation, citation]
     block = CitationBlock(citations)
     assert str(block) == "[Author @test 2020; Author @test 2020]"
+
+
+def test_links_not_citations():
+    """Test that non-citations are not parsed as citations"""
+    markdown = "This is [google](www.google.com)."
+    blocks = CitationBlock.from_markdown(markdown)
+    assert len(blocks) == 0

--- a/test_files/test_integration.py
+++ b/test_files/test_integration.py
@@ -187,3 +187,12 @@ def test_full_bib_command_with_pandoc(pandoc_plugin):
     assert "[^test2]: Author F, Author S (2019b)" in result
     assert "[^Bivort2016]: De Bivort BL, Van Swinderen B (2016)" in result
     assert "[^test_citavi]: Author F, Author S (2019c)" in result
+
+
+def test_leaving_non_citations(plugin):
+    """Test that non-citations are not parsed as citations"""
+    markdown = "This is not a citation [google](www.google.com). But this is a citation [@test]."
+    result = plugin.on_page_markdown(markdown, None, None, None)
+
+    assert "[^test]" in result
+    assert "[google](www.google.com)" in result


### PR DESCRIPTION
The code was not checking if the cite blocks were valid, resulting in any link being treated a a cite block with 0 citations. Eventually the link would be overwritten in the raw markdown. This ensures that doesn't happen anymore by ensuring the block isn't made. I also added in an integration test just in case .

This should fix #289 