### PR TITLE
Allow empty CSL

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -4,3 +4,5 @@ pytest-pretty==1.2.0
 mypy==1.15.0
 ruff==0.9.9
 types-requests~=2.32.0
+pypandoc; sys_platform == 'darwin'
+pypandoc_binary; sys_platform != 'darwin'

--- a/src/mkdocs_bibtex/citation.py
+++ b/src/mkdocs_bibtex/citation.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import List
 import re
 
 
@@ -28,7 +27,7 @@ class Citation:
         return " ".join(parts)
 
     @classmethod
-    def from_markdown(cls, markdown: str) -> List["Citation"]:
+    def from_markdown(cls, markdown: str) -> list["Citation"]:
         """Extracts citations from a markdown string"""
         citations = []
 
@@ -46,7 +45,7 @@ class Citation:
 
 @dataclass
 class CitationBlock:
-    citations: List[Citation]
+    citations: list[Citation]
     raw: str = ""
 
     def __str__(self) -> str:
@@ -56,7 +55,7 @@ class CitationBlock:
         return "[" + "; ".join(str(citation) for citation in self.citations) + "]"
 
     @classmethod
-    def from_markdown(cls, markdown: str) -> List["CitationBlock"]:
+    def from_markdown(cls, markdown: str) -> list["CitationBlock"]:
         """Extracts citation blocks from a markdown string"""
         """
         Given a markdown string
@@ -83,8 +82,11 @@ class InlineReference:
     def __str__(self) -> str:
         return f"@{self.key}"
 
+    def __hash__(self) -> int:
+        return hash(self.key)
+
     @classmethod
-    def from_markdown(cls, markdown: str) -> List["InlineReference"]:
+    def from_markdown(cls, markdown: str) -> list["InlineReference"]:
         """Finds inline references in the markdown text. Only use this after processing all regular citations"""
         inline_references = [
             InlineReference(key=match.group("key")) for match in INLINE_REFERENCE_REGEX.finditer(markdown) if match

--- a/src/mkdocs_bibtex/plugin.py
+++ b/src/mkdocs_bibtex/plugin.py
@@ -112,7 +112,7 @@ class BibTexPlugin(BasePlugin[BibTexConfig]):
         if self.config.bib_by_default and markdown.count(bib_command) == 0:
             markdown += f"\n{bib_command}"
 
-        # 4. Insert in the bibliopgrahy text into the markdown
+        # 4. Insert in the bibliography text into the markdown
         citations = OrderedDict()
         for block in cite_blocks:
             for citation in block.citations:

--- a/src/mkdocs_bibtex/registry.py
+++ b/src/mkdocs_bibtex/registry.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 from typing import Union
 from abc import ABC, abstractmethod
 from mkdocs_bibtex.citation import Citation, CitationBlock, InlineReference
@@ -31,7 +32,7 @@ class ReferenceRegistry(ABC):
         """Validates all citation blocks. Throws an error if any citation block is invalid"""
 
     @abstractmethod
-    def validate_inline_references(self, inline_references: list[InlineReference]) -> list[InlineReference]:
+    def validate_inline_references(self, inline_references: list[InlineReference]) -> set[InlineReference]:
         """Validates inline references and returns only hte valid ones"""
 
     @abstractmethod
@@ -167,7 +168,7 @@ class PandocRegistry(ReferenceRegistry):
             self._reference_cache.update(_references)
         return valid_references
 
-    @property
+    @cached_property
     def bib_data_bibtex(self) -> str:
         """Convert bibliography data to BibTeX format"""
         return self.bib_data.to_string("bibtex")

--- a/src/mkdocs_bibtex/registry.py
+++ b/src/mkdocs_bibtex/registry.py
@@ -33,15 +33,15 @@ class ReferenceRegistry(ABC):
 
     @abstractmethod
     def validate_inline_references(self, inline_references: list[InlineReference]) -> set[InlineReference]:
-        """Validates inline references and returns only hte valid ones"""
+        """Validates inline references and returns only the valid ones"""
 
     @abstractmethod
     def inline_text(self, citation_block: CitationBlock) -> str:
-        """Retreives the inline citation text for a citation block"""
+        """Retrieves the inline citation text for a citation block"""
 
     @abstractmethod
     def reference_text(self, citation: Union[Citation, InlineReference]) -> str:
-        """Retreives the reference text for a citation or inline reference"""
+        """Retrieves the reference text for a citation or inline reference"""
 
 
 class SimpleRegistry(ReferenceRegistry):

--- a/test_files/test_pandoc_registry.py
+++ b/test_files/test_pandoc_registry.py
@@ -90,6 +90,17 @@ def test_validate_citation_blocks_invalid(registry):
         registry.validate_citation_blocks([block])
 
 
+def test_not_inline_text(bib_file):
+    registry = PandocRegistry([bib_file], "", footnote_format="{prefix} {key} {suffix}")
+    citations = [Citation("test", "citation-", "-footnote")]
+    block = CitationBlock(citations)
+    registry.validate_citation_blocks([block])
+    text = registry.inline_text(block)
+    assert text
+    assert text.startswith("[^citation-")
+    assert text.endswith("-footnote]")
+
+
 def test_inline_text_basic(registry):
     """Test basic inline citation formatting with different styles"""
     citations = [Citation("test", "", "")]


### PR DESCRIPTION
It seems like Pandoc registry should allow for empty CSL (even if it doesn't make much sense), given the logic in the method `_check_csl_type` and elswhere.

This PR, to be merged after #303, if at all:

- Properly skips the csl argument to pandoc when there is no CSL file
- Adds support for prefix, suffix to the footnote_format string
- Adds a test for a chunk of `validate_citation_blocks` that wasn't covered because it's only triggered if csl_file is empty
- Fixes some very minor typos here and there