### PR TITLE
Added function to resolve bib_dir and bib_file paths to the mkdocs.yaml filepath

### DIFF
--- a/src/mkdocs_bibtex/plugin.py
+++ b/src/mkdocs_bibtex/plugin.py
@@ -15,6 +15,7 @@ from mkdocs.exceptions import ConfigurationError
 from mkdocs_bibtex.utils import (
     tempfile_from_url,
     log,
+    get_path_relative_to_mkdocs_yaml,
 )
 
 
@@ -47,9 +48,11 @@ class BibTexPlugin(BasePlugin[BibTexConfig]):
             if is_url:
                 bibfiles.append(tempfile_from_url("bib file", self.config.bib_file, ".bib"))
             else:
-                bibfiles.append(self.config.bib_file)
+                bib_file = get_path_relative_to_mkdocs_yaml(self.config.bib_file, config)
+                bibfiles.append(bib_file)
         elif self.config.bib_dir is not None:
-            bibfiles.extend(Path(self.config.bib_dir).rglob("*.bib"))
+            bib_dir = get_path_relative_to_mkdocs_yaml(self.config.bib_dir, config)
+            bibfiles.extend(Path(bib_dir).rglob("*.bib"))
         else:  # pragma: no cover
             raise ConfigurationError("Must supply a bibtex file or directory for bibtex files")
 

--- a/src/mkdocs_bibtex/utils.py
+++ b/src/mkdocs_bibtex/utils.py
@@ -1,7 +1,9 @@
+import os
 import logging
 import requests
 import tempfile
 import urllib.parse
+from mkdocs.config.defaults import MkDocsConfig
 
 
 # Grab a logger
@@ -85,3 +87,8 @@ def sanitize_zotero_query(url: str) -> str:
         query=urllib.parse.urlencode(query={**query_params, **updated_query_params}),
         fragment=parsed_url.fragment,
     ).geturl()
+
+def get_path_relative_to_mkdocs_yaml(path: str, config: MkDocsConfig) -> str:
+    """Get the relative path of a file to the mkdocs.yaml file."""
+    mkdocs_rel_path = os.path.normpath(os.path.join(os.path.dirname(config.config_file_path), path))
+    return mkdocs_rel_path

--- a/test_files/test_utils.py
+++ b/test_files/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
-from mkdocs_bibtex.utils import sanitize_zotero_query, tempfile_from_zotero_url
+from mkdocs_bibtex.utils import sanitize_zotero_query, tempfile_from_zotero_url, get_path_relative_to_mkdocs_yaml
+from unittest.mock import MagicMock
 import collections.abc
 import os
 import random
@@ -99,3 +100,16 @@ def generate_bibtex_entries(n: int) -> list[str]:
     year = {{{year}}},
 """)
     return entries
+
+def test_get_path_relative_to_mkdocs_yaml():
+    """Test the get_path_relative_to_mkdocs_yaml function."""
+    # Set path
+    path = 'example/path/to/bibtex.bib'
+    # Set mock mkdocs config file path
+    mock_mkdocs_config = MagicMock()
+    mock_mkdocs_config.config_file_path = '/path/to/mkdocs.yaml'
+    # Check that the function returns the expected path
+    expected_output = '/path/to/example/path/to/bibtex.bib'
+    output = get_path_relative_to_mkdocs_yaml(path, mock_mkdocs_config)
+    
+    assert output == expected_output


### PR DESCRIPTION
Fixes #309.

- [x] Added `get_path_relative_to_mkdocs_yaml` function within `utils.py`, to resolve paths relative to the `mkdocs.yaml` config file.
- [x] Added test to the `get_path_relative_to_mkdocs_yaml` function
- [x] Added steps to resolve paths of `bib_file` and `bib_dir` within the `plugin.py`, as specified in the issue.

## Testing
- All `pytest` tests pass.
- With the updates installed in the Python environment, when running `mkdocs` commands with the `-f`/`--config-file` option and with the filesystem tree as the one in the issue, the commands succeed.