### PR TITLE
Regular expressions for parsing pandoc output do not work on Windows

### DIFF
--- a/src/mkdocs_bibtex/registry.py
+++ b/src/mkdocs_bibtex/registry.py
@@ -222,10 +222,10 @@ link-citations: false
         reference_cache = {}
 
         # Pattern for format with .csl-left-margin and .csl-right-inline
-        pattern1 = r"::: \{#ref-(?P<key>[^\s]+) .csl-entry\}\n\[.*?\]\{\.csl-left-margin\}\[(?P<citation>.*?)\]\{\.csl-right-inline\}"  # noqa: E501
+        pattern1 = r"::: \{#ref-(?P<key>[^\s]+) .csl-entry\}\r?\n\[.*?\]\{\.csl-left-margin\}\[(?P<citation>.*?)\]\{\.csl-right-inline\}"  # noqa: E501
 
         # Pattern for simple reference format
-        pattern2 = r"::: \{#ref-(?P<key>[^\s]+) .csl-entry\}\n(?P<citation>.*?)(?=:::|$)"
+        pattern2 = r"::: \{#ref-(?P<key>[^\s]+) .csl-entry\}\r?\n(?P<citation>.*?)(?=:::|$)"
 
         # Try first pattern
         matches1 = re.finditer(pattern1, references, re.DOTALL)


### PR DESCRIPTION
When running `mkdocs` on a Windows system (yes, I know, why would one, but it is what it is), the regular expressions for parsing the citations output by pandoc do not work and the `reference_cache` stays empty. The problem are the Windows-style linebreaks of form `\r\n` rather than `\n`.

This patch fixes the issue.