### PR TITLE
Enable escaping inline citations

### DIFF
--- a/src/mkdocs_bibtex/citation.py
+++ b/src/mkdocs_bibtex/citation.py
@@ -5,7 +5,7 @@ import re
 CITATION_REGEX = re.compile(r"(?:(?P<prefix>[^@;]*?)\s*)?@(?P<key>[\w-]+)(?:,\s*(?P<suffix>[^;]+))?")
 CITATION_BLOCK_REGEX = re.compile(r"\[(.*?)\]")
 EMAIL_REGEX = re.compile(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}")
-INLINE_REFERENCE_REGEX = re.compile(r"(?<![\[\w])@(?P<key>[\w:-]+)(?![\w\s]*\])")
+INLINE_REFERENCE_REGEX = re.compile(r"(?<!\\)(?<![\[\w])@(?P<key>[\w:-]+)(?![^\[\]]*\])")
 
 
 @dataclass

--- a/test_files/test_citation.py
+++ b/test_files/test_citation.py
@@ -3,7 +3,6 @@ This test file tests the citation module and ensures it is compatible with
 pybtex basic citations and pandoc citation formattting
 """
 
-import pytest
 from mkdocs_bibtex.citation import Citation, CitationBlock, InlineReference
 
 

--- a/test_files/test_citation.py
+++ b/test_files/test_citation.py
@@ -166,6 +166,8 @@ def test_inline_citation():
         "This text contains unprocessed citation [@citation]",
         # Don't capture citations with prefixes and affixes
         "This text contains unprocessed citation [see @citation p22]",
+        # This shouldn't be considered inline
+        "This is not an inline citation \@mystuff"
     ]
 
     for markdown in inline_citations:
@@ -176,8 +178,6 @@ def test_inline_citation():
         citations = InlineReference.from_markdown(markdown)
         assert len(citations) == 0
 
-
-@pytest.mark.xfail(reason="This is a hard case to not capture and is currently an expected failure")
 def test_inline_citation_on_block():
     bad_markdown = "[see @test1, p. 123; @test2, p. 456; -@test3]"
     citations = InlineReference.from_markdown(bad_markdown)

--- a/test_files/test_utils.py
+++ b/test_files/test_utils.py
@@ -111,5 +111,5 @@ def test_get_path_relative_to_mkdocs_yaml():
     # Check that the function returns the expected path
     expected_output = '/path/to/example/path/to/bibtex.bib'
     output = get_path_relative_to_mkdocs_yaml(path, mock_mkdocs_config)
-    
+
     assert output == expected_output


### PR DESCRIPTION
This should fix escaping inline citations. Aiming to fix #312 